### PR TITLE
cleanup all the resources before removing the finalizer

### DIFF
--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -119,6 +119,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	// find all the deployed resources and check to see if they still exists
 	foundResource := false
 	resources := releaseutil.SplitManifests(hr.Status.DeployedRelease.Manifest)
+
 	for _, resource := range resources {
 		var u unstructured.Unstructured
 		if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
@@ -193,6 +194,7 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 
 	// resource is not in the namespace. find the resource in the cluster.
 	resource.SetNamespace("")
+
 	found, _ = r.isResourceExists(resource, hr)
 	if found {
 		if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
@@ -225,6 +227,7 @@ func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructu
 		klog.Info("Removal of HelmRelease ", hr.GetNamespace(), "/", hr.GetName(),
 			" is blocked by resource: ", resource.GetNamespace(), "/", resource.GetName(),
 			" GVK: ", resource.GroupVersionKind())
+
 		return true, nil
 	}
 

--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -173,7 +173,8 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	return *horResult
 }
 
-//isResourceDeleted finds the given resource, if it exists then delete it. return true if the resource is already deleted.
+//isResourceDeleted finds the given resource, if it exists then delete it.
+// return true if the resource is already deleted.
 func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstructured, hr *appv1.HelmRelease) bool {
 	// find the resource in the namespace
 	found, err := r.isResourceExists(resource, hr)
@@ -186,7 +187,7 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 	if found {
 		if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
 			klog.Error(err, " - Failed to delete resource: ", resource.GetNamespace(), "/", resource.GetName(),
-				" GVK: ", resource.GroupVersionKind())
+				" ", resource.GroupVersionKind())
 		}
 
 		return false
@@ -199,7 +200,7 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 	if found {
 		if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
 			klog.Error(err, " - Failed to delete resource: ", resource.GetName(),
-				" GVK: ", resource.GroupVersionKind())
+				" ", resource.GroupVersionKind())
 		}
 
 		return false
@@ -213,7 +214,7 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructured,
 	hr *appv1.HelmRelease) (bool, error) {
 	klog.V(2).Info("Getting resource: ", resource.GetNamespace(), "/", resource.GetName(),
-		" GVK: ", resource.GroupVersionKind())
+		" ", resource.GroupVersionKind())
 
 	nsn := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
 	if resource.GetNamespace() == "" {
@@ -226,7 +227,7 @@ func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructu
 	if err == nil {
 		klog.Info("Removal of HelmRelease ", hr.GetNamespace(), "/", hr.GetName(),
 			" is blocked by resource: ", resource.GetNamespace(), "/", resource.GetName(),
-			" GVK: ", resource.GroupVersionKind())
+			" ", resource.GroupVersionKind())
 
 		return true, nil
 	}

--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/operator-framework/operator-sdk/pkg/helm/release"
-	helmrelease "github.com/operator-framework/operator-sdk/pkg/helm/release"
+	helmoperator "github.com/operator-framework/operator-sdk/pkg/helm/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,13 +61,13 @@ const (
  Justification: The operator-sdk helm operator strips the finalizer even in cases where resources still exist.
 */
 func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
-	manager helmrelease.Manager) HelmOperatorReconcileResult {
+	manager helmoperator.Manager) helmOperatorReconcileResult {
 	// sanity check
 	if hr.GetDeletionTimestamp() == nil {
 		klog.Error("uninstallRelease() should only be called when the DeletionTimestamp is populated ",
 			hr.GetNamespace(), "/", hr.GetName())
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, nil}
 
 		return *horResult
 	}
@@ -75,7 +75,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	if !contains(hr.GetFinalizers(), finalizer) {
 		klog.Info("HelmRelease is terminated, skipping reconciliation ", hr.GetNamespace(), "/", hr.GetName())
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, nil}
 
 		return *horResult
 	}
@@ -94,7 +94,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 		})
 
 		_ = r.updateResourceStatus(hr)
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
 	}
@@ -112,7 +112,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	if err := r.updateResourceStatus(hr); err != nil {
 		klog.Info("Failed to update HelmRelease status ", hr.GetNamespace(), "/", hr.GetName())
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
 	}
@@ -125,7 +125,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 		var u unstructured.Unstructured
 		if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
 			klog.Error(err, " - Failed to unmarshal resource ", resource)
-			horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+			horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 			return *horResult
 		}
@@ -153,7 +153,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 
 	if foundResource {
 		// at least one resource still exists, check again after 10 seconds
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Second * 10}, nil}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Second * 10}, nil}
 
 		return *horResult
 	}
@@ -165,12 +165,12 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	if err := r.updateResource(hr); err != nil {
 		klog.Error(err, " - Failed to strip HelmRelease uninstall finalizer ", hr.GetNamespace(), "/", hr.GetName())
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
 	}
 
-	horResult := &HelmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Minute * 2}, nil}
+	horResult := &helmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Minute * 1}, nil}
 
 	return *horResult
 }
@@ -233,13 +233,13 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
  force the release upgrade. For example, to increment the helm revision number.
 */
 func (r *ReconcileHelmRelease) forceUpgradeRelease(hr *appv1.HelmRelease,
-	manager helmrelease.Manager) HelmOperatorReconcileResult {
+	manager helmoperator.Manager) helmOperatorReconcileResult {
 	hrforce := hasBooleanAnnotation(hr, HelmReleaseUpgradeForceAnnotation)
 	if !hrforce {
 		klog.Error("forceUpgradeRelease() should only be called when the annotation is set to true ",
 			HelmReleaseUpgradeForceAnnotation)
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, nil}
 
 		return *horResult
 	}
@@ -261,7 +261,7 @@ func (r *ReconcileHelmRelease) forceUpgradeRelease(hr *appv1.HelmRelease,
 
 		_ = r.updateResourceStatus(hr)
 
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+		horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
 	}
@@ -290,7 +290,7 @@ func (r *ReconcileHelmRelease) forceUpgradeRelease(hr *appv1.HelmRelease,
 	}
 
 	err = r.updateResourceStatus(hr)
-	horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+	horResult := &helmOperatorReconcileResult{reconcile.Result{}, err}
 
 	return *horResult
 }

--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -61,10 +61,10 @@ const (
 */
 func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	manager helmrelease.Manager) HelmOperatorReconcileResult {
-
 	// sanity check
 	if hr.GetDeletionTimestamp() == nil {
-		klog.Error("uninstallRelease() should only be called when the DeletionTimestamp is populated ", hr.GetNamespace, "/", hr.GetName)
+		klog.Error("uninstallRelease() should only be called when the DeletionTimestamp is populated ",
+			hr.GetNamespace(), "/", hr.GetName())
 
 		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
 
@@ -72,7 +72,8 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 	}
 
 	if !contains(hr.GetFinalizers(), finalizer) {
-		klog.Info("HelmRelease is terminated, skipping reconciliation ", hr.GetNamespace, "/", hr.GetName)
+		klog.Info("HelmRelease is terminated, skipping reconciliation ", hr.GetNamespace(), "/", hr.GetName())
+
 		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
 
 		return *horResult
@@ -83,13 +84,14 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 
 	_, err := manager.UninstallRelease(context.TODO())
 	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-		klog.Error(err, "Failed to uninstall HelmRelease ", hr.GetNamespace, "/", hr.GetName)
+		klog.Error(err, "Failed to uninstall HelmRelease ", hr.GetNamespace(), "/", hr.GetName())
 		hr.Status.SetCondition(appv1.HelmAppCondition{
 			Type:    appv1.ConditionReleaseFailed,
 			Status:  appv1.StatusTrue,
 			Reason:  appv1.ReasonUninstallError,
 			Message: err.Error(),
 		})
+
 		_ = r.updateResourceStatus(hr)
 		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
 
@@ -108,6 +110,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 
 	if err := r.updateResourceStatus(hr); err != nil {
 		klog.Info("Failed to update HelmRelease status ", hr.GetNamespace(), "/", hr.GetName())
+
 		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
@@ -133,6 +136,7 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 		o := &unstructured.Unstructured{}
 		o.SetName(u.GetName())
 		o.SetGroupVersionKind(u.GroupVersionKind())
+
 		if u.GetNamespace() == "" {
 			o.SetNamespace(hr.GetNamespace())
 		}
@@ -154,8 +158,10 @@ func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
 
 	klog.Info("HelmRelease ", hr.GetNamespace(), "/", hr.GetName(), " all DeployedRelease resources are deleted")
 	controllerutil.RemoveFinalizer(hr, finalizer)
+
 	if err := r.updateResource(hr); err != nil {
 		klog.Error(err, " - Failed to strip HelmRelease uninstall finalizer ", hr.GetNamespace(), "/", hr.GetName())
+
 		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
 
 		return *horResult
@@ -210,6 +216,7 @@ func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructu
 	nsn := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
 	if resource.GetNamespace() == "" {
 		nsn = types.NamespacedName{Name: resource.GetName()}
+
 		resource.SetName("")
 	}
 
@@ -240,7 +247,6 @@ func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructu
 */
 func (r *ReconcileHelmRelease) forceUpgradeRelease(hr *appv1.HelmRelease,
 	manager helmrelease.Manager) HelmOperatorReconcileResult {
-
 	hrforce := hasBooleanAnnotation(hr, HelmReleaseUpgradeForceAnnotation)
 	if !hrforce {
 		klog.Error("forceUpgradeRelease() should only be called when the annotation is set to true ",
@@ -308,5 +314,6 @@ func contains(l []string, s string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file consist of functionalities that are originally from the operator-sdk helm operator
+https://github.com/operator-framework/operator-sdk/tree/master/pkg/helm
+
+The goal is to always use the operator-sdk api unless it's absolutely necessary to make changes
+to meet some of helmrelease's requirements.
+*/
+
+package helmrelease
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/operator-framework/operator-sdk/pkg/helm/release"
+	helmrelease "github.com/operator-framework/operator-sdk/pkg/helm/release"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
+)
+
+const (
+	finalizer = "uninstall-helm-release"
+
+	// OperatorSDKUpgradeForceAnnotation to perform the equalivent of `helm upgrade --force`
+	OperatorSDKUpgradeForceAnnotation = "helm.operator-sdk/upgrade-force"
+)
+
+/*
+ uninstallRelease uninstalls the helm release. It should only be call when there is a DeletionTimestamp.
+
+ Origin: https://github.com/operator-framework/operator-sdk/blob/master/pkg/helm/controller/reconcile.go
+ The uninstall path inside Reconcile()
+ Modification: Significant. Added resources check to make sure all resources are deleted before removing the finalizer.
+ Justification: The operator-sdk helm operator strips the finalizer even in cases where resources still exist.
+*/
+func (r *ReconcileHelmRelease) uninstallRelease(hr *appv1.HelmRelease,
+	manager helmrelease.Manager) HelmOperatorReconcileResult {
+
+	// sanity check
+	if hr.GetDeletionTimestamp() == nil {
+		klog.Error("uninstallRelease() should only be called when the DeletionTimestamp is populated ", hr.GetNamespace, "/", hr.GetName)
+
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+
+		return *horResult
+	}
+
+	if !contains(hr.GetFinalizers(), finalizer) {
+		klog.Info("HelmRelease is terminated, skipping reconciliation ", hr.GetNamespace, "/", hr.GetName)
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+
+		return *horResult
+	}
+
+	hr.Status.RemoveCondition(appv1.ConditionTimedout)
+	hr.Status.RemoveCondition(appv1.ConditionIrreconcilable)
+
+	_, err := manager.UninstallRelease(context.TODO())
+	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+		klog.Error(err, "Failed to uninstall HelmRelease ", hr.GetNamespace, "/", hr.GetName)
+		hr.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonUninstallError,
+			Message: err.Error(),
+		})
+		_ = r.updateResourceStatus(hr)
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+		return *horResult
+	}
+
+	klog.Info("Uninstalled HelmRelease ", hr.GetNamespace(), ",", hr.GetName())
+
+	hr.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+	hr.Status.SetCondition(appv1.HelmAppCondition{
+		Type:   appv1.ConditionDeployed,
+		Status: appv1.StatusFalse,
+		Reason: appv1.ReasonUninstallSuccessful +
+			" but not all DeployedRelease resources are deleted",
+	})
+
+	if err := r.updateResourceStatus(hr); err != nil {
+		klog.Info("Failed to update HelmRelease status ", hr.GetNamespace(), "/", hr.GetName())
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+		return *horResult
+	}
+
+	// find all the deployed resources and check to see if they still exists
+	foundResource := false
+	resources := releaseutil.SplitManifests(hr.Status.DeployedRelease.Manifest)
+	for _, resource := range resources {
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
+			klog.Error(err, " - Failed to unmarshal resource ", resource)
+			horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+			return *horResult
+		}
+
+		gvk := u.GroupVersionKind()
+		if gvk.Empty() {
+			continue
+		}
+
+		o := &unstructured.Unstructured{}
+		o.SetName(u.GetName())
+		o.SetGroupVersionKind(u.GroupVersionKind())
+		if u.GetNamespace() == "" {
+			o.SetNamespace(hr.GetNamespace())
+		}
+
+		if r.isResourceDeleted(o, hr) {
+			// resource is already delete, check the next one.
+			continue
+		}
+
+		foundResource = true
+	}
+
+	if foundResource {
+		// at least one resource still exists, check again after 10 seconds
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Second * 10}, nil}
+
+		return *horResult
+	}
+
+	klog.Info("HelmRelease ", hr.GetNamespace(), "/", hr.GetName(), " all DeployedRelease resources are deleted")
+	controllerutil.RemoveFinalizer(hr, finalizer)
+	if err := r.updateResource(hr); err != nil {
+		klog.Error(err, " - Failed to strip HelmRelease uninstall finalizer ", hr.GetNamespace(), "/", hr.GetName())
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+		return *horResult
+	}
+
+	horResult := &HelmOperatorReconcileResult{reconcile.Result{RequeueAfter: time.Minute * 2}, nil}
+
+	return *horResult
+}
+
+//isResourceDeleted finds the given resource, if it exists then delete it. return true if the resource is already deleted.
+func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstructured, hr *appv1.HelmRelease) bool {
+	// find the resource in the namespace
+	found, err := r.isResourceExists(resource, hr)
+	if err != nil {
+		klog.Error(err, " - Failed to lookup resource ", resource)
+
+		return false
+	}
+
+	if found {
+		if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
+			klog.Error(err, " - Failed to delete resource: ", resource.GetNamespace(), "/", resource.GetName(),
+				" GVK: ", resource.GroupVersionKind())
+		}
+
+		return false
+	}
+
+	// resource is not in the namespace. find the resource in the cluster.
+	resource.SetNamespace("")
+	found, _ = r.isResourceExists(resource, hr)
+	if found {
+		if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
+			klog.Error(err, " - Failed to delete resource: ", resource.GetName(),
+				" GVK: ", resource.GroupVersionKind())
+		}
+
+		return false
+	}
+
+	// resource is not in the cluster either. return true to confirm that the resource is already delete.
+
+	return true
+}
+
+func (r *ReconcileHelmRelease) isResourceExists(resource *unstructured.Unstructured,
+	hr *appv1.HelmRelease) (bool, error) {
+	klog.V(2).Info("Getting resource: ", resource.GetNamespace(), "/", resource.GetName(),
+		" GVK: ", resource.GroupVersionKind())
+
+	nsn := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
+	if resource.GetNamespace() == "" {
+		nsn = types.NamespacedName{Name: resource.GetName()}
+		resource.SetName("")
+	}
+
+	err := r.GetClient().Get(context.TODO(), nsn, resource)
+	if err == nil {
+		klog.Info("Removal of HelmRelease ", hr.GetNamespace(), "/", hr.GetName(),
+			" is blocked by resource: ", resource.GetNamespace(), "/", resource.GetName(),
+			" GVK: ", resource.GroupVersionKind())
+		return true, nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		return false, nil // resource is deleted
+	}
+
+	return false, err
+}
+
+/*
+ forceUpgradeRelease forces the upgrade on the helm release.
+ It should only be call when there is a HelmReleaseUpgradeForceAnnotation set to true.
+
+ Origin: https://github.com/operator-framework/operator-sdk/blob/master/pkg/helm/controller/reconcile.go
+ The upgrade path inside Reconcile()
+ Modification: Minimal. Removed the IsUpgradeRequired() check.
+ Justification: Operator-sdk always skips unnecessary upgrades. Sometimes, helmrelease might need to
+ force the release upgrade. For example, to increment the helm revision number.
+*/
+func (r *ReconcileHelmRelease) forceUpgradeRelease(hr *appv1.HelmRelease,
+	manager helmrelease.Manager) HelmOperatorReconcileResult {
+
+	hrforce := hasBooleanAnnotation(hr, HelmReleaseUpgradeForceAnnotation)
+	if !hrforce {
+		klog.Error("forceUpgradeRelease() should only be called when the annotation is set to true ",
+			HelmReleaseUpgradeForceAnnotation)
+
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, nil}
+
+		return *horResult
+	}
+
+	hr.Status.RemoveCondition(appv1.ConditionTimedout)
+	hr.Status.RemoveCondition(appv1.ConditionIrreconcilable)
+
+	force := hasBooleanAnnotation(hr, OperatorSDKUpgradeForceAnnotation)
+	_, upgradedRelease, err := manager.UpdateRelease(context.TODO(), release.ForceUpdate(force))
+
+	if err != nil {
+		klog.Error(err, "Release failed")
+		hr.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonUpdateError,
+			Message: err.Error(),
+		})
+
+		_ = r.updateResourceStatus(hr)
+
+		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+		return *horResult
+	}
+
+	hr.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+
+	klog.Info("Upgraded release", "force", force)
+	klog.V(1).Info("Config values", "values", upgradedRelease.Config)
+
+	message := ""
+
+	if upgradedRelease.Info != nil {
+		message = upgradedRelease.Info.Notes
+	}
+
+	hr.Status.SetCondition(appv1.HelmAppCondition{
+		Type:    appv1.ConditionDeployed,
+		Status:  appv1.StatusTrue,
+		Reason:  appv1.ReasonUpdateSuccessful,
+		Message: message,
+	})
+
+	hr.Status.DeployedRelease = &appv1.HelmAppRelease{
+		Name:     upgradedRelease.Name,
+		Manifest: upgradedRelease.Manifest,
+	}
+
+	err = r.updateResourceStatus(hr)
+	horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
+
+	return *horResult
+}
+
+func contains(l []string, s string) bool {
+	for _, elem := range l {
+		if elem == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/helmrelease/helm_operator_test.go
+++ b/pkg/controller/helmrelease/helm_operator_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file consist of functionalities that are originally from the operator-sdk helm operator
+https://github.com/operator-framework/operator-sdk/tree/master/pkg/helm
+
+The goal is to always use the operator-sdk api unless it's absolutely necessary to make changes
+to meet some of helmrelease's requirements.
+*/
+
+package helmrelease
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/onsi/gomega"
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
+	helmoperator "github.com/operator-framework/operator-sdk/pkg/helm/release"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestHelmOperator_uninstallRelease(t *testing.T) {
+	testscheme := scheme.Scheme
+
+	testscheme.AddKnownTypes(appv1.SchemeGroupVersion, &appv1.HelmRelease{})
+
+	testHelmRelease := &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-helmrelease",
+			Namespace: helmReleaseNS,
+		},
+	}
+
+	testDeletingHelmReleaseNilFinalizers := &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-helmrelease",
+			Namespace:         helmReleaseNS,
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+	}
+	testDeletingHelmRelease := &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-helmrelease",
+			Namespace:         helmReleaseNS,
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{finalizer},
+		},
+		Repo: appv1.HelmReleaseRepo{
+			Source: &appv1.Source{
+				SourceType: appv1.HelmRepoSourceType,
+				HelmRepo: &appv1.HelmRepo{
+					Urls: []string{
+						"https://raw.github.com/open-cluster-management/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-3-0.1.0.tgz"},
+				},
+			},
+			ChartName: "subscription-release-test-1",
+		},
+	}
+
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+		LeaderElection:     false,
+	})
+	if err != nil {
+		t.Fatal("Failed to create manager", err)
+	}
+
+	rec := &ReconcileHelmRelease{
+		mgr,
+	}
+
+	stopMgr, mgrStopped := StartTestManager(mgr, gomega.NewGomegaWithT(t))
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	err = mgr.GetClient().Create(context.TODO(), testDeletingHelmRelease)
+	if err != nil {
+		t.Fatal("Failed to create helmrelease", err)
+	}
+
+	time.Sleep(4 * time.Second)
+
+	helmReleaseKey := types.NamespacedName{
+		Name:      testDeletingHelmRelease.GetName(),
+		Namespace: helmReleaseNS,
+	}
+
+	mgr.GetClient().Get(context.TODO(), helmReleaseKey, testDeletingHelmRelease)
+
+	spec := make(map[string]interface{})
+	yaml.Unmarshal([]byte("{\"\":\"\"}"), &spec)
+	testDeletingHelmRelease.Spec = spec
+
+	mgr.GetClient().Update(context.TODO(), testDeletingHelmRelease)
+
+	time.Sleep(4 * time.Second)
+
+	err = mgr.GetClient().Get(context.TODO(), helmReleaseKey, testDeletingHelmRelease)
+	if err != nil {
+		t.Fatal("Failed to get helmrelease", err)
+	}
+
+	factory, err := rec.newHelmOperatorManagerFactory(testDeletingHelmRelease)
+	if err != nil {
+		t.Fatal("Failed to create factory", err)
+	}
+
+	manager, err := rec.newHelmOperatorManager(testDeletingHelmRelease, reconcile.Request{NamespacedName: helmReleaseKey}, factory)
+	if err != nil {
+		t.Fatal("Failed to create manager", err)
+	}
+
+	type args struct {
+		helmRelease *appv1.HelmRelease
+		manager     helmoperator.Manager
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    helmOperatorReconcileResult
+		wantErr bool
+	}{
+		{
+			name: "DeletionTimestamp is nil",
+			args: args{
+				helmRelease: testHelmRelease,
+			},
+			want:    helmOperatorReconcileResult{reconcile.Result{}, nil},
+			wantErr: false,
+		},
+		{
+			name: "finalizers is nil",
+			args: args{
+				helmRelease: testDeletingHelmReleaseNilFinalizers,
+			},
+			want:    helmOperatorReconcileResult{reconcile.Result{}, nil},
+			wantErr: false,
+		},
+		{
+			name: "uninstall",
+			args: args{
+				helmRelease: testDeletingHelmRelease,
+				manager:     manager,
+			},
+			want:    helmOperatorReconcileResult{reconcile.Result{}, nil},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileHelmRelease{}
+
+			got := r.uninstallRelease(tt.args.helmRelease, tt.args.manager)
+
+			if (got.Error != nil) != tt.wantErr {
+				t.Errorf("ReconcileHelmRelease.uninstallRelease() error = %v, wantErr %v", got.Error, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileHelmRelease.uninstallRelease() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelmOperator_forceUpgradeRelease(t *testing.T) {
+	testscheme := scheme.Scheme
+
+	testscheme.AddKnownTypes(appv1.SchemeGroupVersion, &appv1.HelmRelease{})
+
+	testHelmReleaseNoAnnotations := &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-helmrelease",
+			Namespace: helmReleaseNS,
+		},
+	}
+
+	testHelmReleaseForceFalse := &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-helmrelease",
+			Namespace:   helmReleaseNS,
+			Annotations: map[string]string{HelmReleaseUpgradeForceAnnotation: "false"},
+		},
+	}
+
+	type args struct {
+		helmRelease *appv1.HelmRelease
+		manager     helmoperator.Manager
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    helmOperatorReconcileResult
+		wantErr bool
+	}{
+		{
+			name: "no force annotation",
+			args: args{
+				helmRelease: testHelmReleaseNoAnnotations,
+			},
+			want:    helmOperatorReconcileResult{reconcile.Result{}, nil},
+			wantErr: false,
+		},
+		{
+			name: "force annotation set to false",
+			args: args{
+				helmRelease: testHelmReleaseForceFalse,
+			},
+			want:    helmOperatorReconcileResult{reconcile.Result{}, nil},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileHelmRelease{}
+
+			got := r.uninstallRelease(tt.args.helmRelease, tt.args.manager)
+
+			if (got.Error != nil) != tt.wantErr {
+				t.Errorf("ReconcileHelmRelease.forceUpgradeRelease() error = %v, wantErr %v", got.Error, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileHelmRelease.forceUpgradeRelease() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -140,8 +140,8 @@ type ReconcileHelmRelease struct {
 	manager.Manager
 }
 
-// HelmOperatorReconcileResult holds the result of the HelmOperatorReconcile
-type HelmOperatorReconcileResult struct {
+// helmOperatorReconcileResult holds the result of the HelmOperatorReconcile
+type helmOperatorReconcileResult struct {
 	Result reconcile.Result
 	Error  error
 }
@@ -258,7 +258,7 @@ func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Re
 		ManagerFactory: factory,
 	}
 
-	c := make(chan HelmOperatorReconcileResult)
+	c := make(chan helmOperatorReconcileResult)
 
 	go func() {
 		res := helmOperatorReconcile(request, *hor)
@@ -271,9 +271,9 @@ func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Re
 
 // helmOperatorReconcile calls the Helm Operator reconcile and returns the result
 func helmOperatorReconcile(request reconcile.Request,
-	hor helmOperatorController.HelmOperatorReconciler) HelmOperatorReconcileResult {
+	hor helmOperatorController.HelmOperatorReconciler) helmOperatorReconcileResult {
 	result, err := hor.Reconcile(request)
-	horResult := &HelmOperatorReconcileResult{result, err}
+	horResult := &helmOperatorReconcileResult{result, err}
 
 	return *horResult
 }
@@ -342,7 +342,7 @@ func (r *ReconcileHelmRelease) processUninstallRelease(hr *appv1.HelmRelease,
 	manager helmoperator.Manager) (reconcile.Result, error) {
 	klog.V(2).Info("Processing uninstall release: ", hr.GetNamespace(), "/", hr.GetName())
 
-	c := make(chan HelmOperatorReconcileResult)
+	c := make(chan helmOperatorReconcileResult)
 
 	go func() {
 		res := r.uninstallRelease(hr, manager)
@@ -358,7 +358,7 @@ func (r *ReconcileHelmRelease) processForceUpgradeRelease(hr *appv1.HelmRelease,
 	manager helmoperator.Manager) (reconcile.Result, error) {
 	klog.V(2).Info("Processing force upgrade: ", hr.GetNamespace(), "/", hr.GetName())
 
-	c := make(chan HelmOperatorReconcileResult)
+	c := make(chan helmOperatorReconcileResult)
 
 	go func() {
 		res := r.forceUpgradeRelease(hr, manager)
@@ -371,7 +371,7 @@ func (r *ReconcileHelmRelease) processForceUpgradeRelease(hr *appv1.HelmRelease,
 
 // processHelmOperatorReconcileResult determines if timeout is necessary
 func (r *ReconcileHelmRelease) processHelmOperatorReconcileResult(hr *appv1.HelmRelease,
-	c chan HelmOperatorReconcileResult) (reconcile.Result, error) {
+	c chan helmOperatorReconcileResult) (reconcile.Result, error) {
 	select {
 	case res := <-c:
 		return res.Result, res.Error

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package helmrelease controller manages the helmreleas CR
+//Package helmrelease controller manages the helmrelease CR
 package helmrelease
 
 import (
@@ -26,13 +26,11 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	helmController "github.com/operator-framework/operator-sdk/pkg/helm/controller"
-	"github.com/operator-framework/operator-sdk/pkg/helm/release"
-	helmrelease "github.com/operator-framework/operator-sdk/pkg/helm/release"
+	helmOperatorController "github.com/operator-framework/operator-sdk/pkg/helm/controller"
+	helmoperator "github.com/operator-framework/operator-sdk/pkg/helm/release"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -50,9 +48,6 @@ const (
 	// MaxConcurrentEnvVar is the constant for env variable HR_MAX_CONCURRENT
 	// which is the maximum concurrent reconcile number
 	MaxConcurrentEnvVar = "HR_MAX_CONCURRENT"
-
-	// OperatorSDKUpgradeForceAnnotation to perform the equalivent of `helm upgrade --force`
-	OperatorSDKUpgradeForceAnnotation = "helm.operator-sdk/upgrade-force"
 
 	// HelmReleaseUpgradeForceAnnotation to force a Helm chart upgrade even if the old and new manifests are the same
 	HelmReleaseUpgradeForceAnnotation = "apps.open-cluster-management.io/hr-upgrade-force"
@@ -174,6 +169,7 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	// setting the nil spec to "":"" allows helmrelease to reconcile with default chart values.
 	if instance.Spec == nil {
 		spec := make(map[string]interface{})
 
@@ -190,11 +186,12 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		}
 	}
 
-	helmReleaseManagerFactory, err := r.newHelmReleaseManagerFactory(instance)
+	// handles the download of the chart as well
+	helmOperatorManagerFactory, err := r.newHelmOperatorManagerFactory(instance)
 	if err != nil {
-		klog.Error(err, "- Failed to create new HelmReleaseManagerFactory: ", instance)
+		klog.Error(err, "- Failed to create new HelmOperatorManagerFactory: ", instance)
 
-		if errUpdate := setErrorStatus(r.GetClient(), instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
+		if errUpdate := r.setErrorStatus(instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
 			return reconcile.Result{}, errUpdate
 		}
 
@@ -203,54 +200,60 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{RequeueAfter: time.Minute * 2}, nil
 	}
 
-	helmReleaseManager, err := r.newHelmReleaseManager(instance, request, helmReleaseManagerFactory)
+	helmOperatorManager, err := r.newHelmOperatorManager(instance, request, helmOperatorManagerFactory)
 	if err != nil {
-		klog.Error(err, "- Failed to create new HelmReleaseManager: ", instance)
+		klog.Error(err, "- Failed to create new HelmOperatorManager: ", instance)
 
-		if errUpdate := setErrorStatus(r.GetClient(), instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
+		if errUpdate := r.setErrorStatus(instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
 			return reconcile.Result{}, errUpdate
 		}
 
 		return reconcile.Result{}, nil
 	}
 
-	if err := helmReleaseManager.Sync(context.TODO()); err != nil {
+	if err := helmOperatorManager.Sync(context.TODO()); err != nil {
 		klog.Error(err, "- Failed to sync HelmRelease: ", instance)
 
-		if errUpdate := setErrorStatus(r.GetClient(), instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
+		if errUpdate := r.setErrorStatus(instance, err, appv1.ConditionIrreconcilable); errUpdate != nil {
 			return reconcile.Result{}, errUpdate
 		}
 
 		return reconcile.Result{}, nil
 	}
 
-	deleted := instance.GetDeletionTimestamp() != nil
+	// delete path, uninstall the helmrelease
+	if instance.GetDeletionTimestamp() != nil {
+		return r.processUninstallRelease(instance, helmOperatorManager)
+	}
 
-	if !deleted &&
-		!containsErrorConditions(instance) &&
-		!helmReleaseManager.IsUpdateRequired() &&
-		helmReleaseManager.IsInstalled() &&
+	// check to see if it's necessary to upgrade
+	if !containsErrorConditions(instance) &&
+		!helmOperatorManager.IsUpdateRequired() &&
+		helmOperatorManager.IsInstalled() &&
 		instance.Status.DeployedRelease != nil {
+
+		// force the upgrade if HelmReleaseUpgradeForceAnnotation is set to true
 		if hasBooleanAnnotation(instance, HelmReleaseUpgradeForceAnnotation) {
-			return processUpgradeRelease(r.GetClient(), instance, helmReleaseManager)
+			return r.processForceUpgradeRelease(instance, helmOperatorManager)
 		}
 
-		klog.Info("Update is not required. Skipping Reconciling HelmRelease:", request)
+		klog.Info("Upgrade is not required. Skipping Reconciling HelmRelease:", request)
 
 		return reconcile.Result{Requeue: false}, nil
 	}
 
-	return processHorReconcile(r.GetClient(), request, instance, helmReleaseManagerFactory)
+	return r.processHelmOperatorReconcile(request, instance, helmOperatorManagerFactory)
 }
 
-// processHorReconcile ensures the horReconcile() returns or it will time it out.
-func processHorReconcile(
-	client client.Client, request reconcile.Request, instance *appv1.HelmRelease, factory helmrelease.ManagerFactory) (
+// processHelmOperatorReconcile ensures the helmOperatorReconcile() returns or it will timeout.
+func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Request, instance *appv1.HelmRelease, factory helmoperator.ManagerFactory) (
 	reconcile.Result, error) {
 	klog.V(2).Info("Processing reconciliation: ", request)
 
-	hor := &helmController.HelmOperatorReconciler{
-		Client:         client,
+	instance.Status.RemoveCondition(appv1.ConditionTimedout)
+
+	hor := &helmOperatorController.HelmOperatorReconciler{
+		Client:         r.GetClient(),
 		GVK:            instance.GroupVersionKind(),
 		ManagerFactory: factory,
 	}
@@ -258,16 +261,16 @@ func processHorReconcile(
 	c := make(chan HelmOperatorReconcileResult)
 
 	go func() {
-		res := horReconcile(request, *hor)
+		res := helmOperatorReconcile(request, *hor)
 		c <- res
 	}()
 
-	// process the horReconcile() return or timeout.
-	return processHelmOperatorReconcileResult(client, instance, c)
+	// process the helmOperatorReconcile() return or timeout.
+	return r.processHelmOperatorReconcileResult(instance, c)
 }
 
-// horReconcile calls the Helm Operator reconcile and returns the result
-func horReconcile(request reconcile.Request, hor helmController.HelmOperatorReconciler) HelmOperatorReconcileResult {
+// helmOperatorReconcile calls the Helm Operator reconcile and returns the result
+func helmOperatorReconcile(request reconcile.Request, hor helmOperatorController.HelmOperatorReconciler) HelmOperatorReconcileResult {
 	result, err := hor.Reconcile(request)
 	horResult := &HelmOperatorReconcileResult{result, err}
 
@@ -289,7 +292,7 @@ func containsErrorConditions(hr *appv1.HelmRelease) bool {
 	return false
 }
 
-func setErrorStatus(client client.StatusClient, hr *appv1.HelmRelease, err error, conditionType appv1.HelmAppConditionType) error {
+func (r *ReconcileHelmRelease) setErrorStatus(hr *appv1.HelmRelease, err error, conditionType appv1.HelmAppConditionType) error {
 	klog.V(1).Info(fmt.Sprintf("Attempting to set %s/%s error status for error: %v", hr.GetNamespace(), hr.GetName(), err))
 
 	hr.Status.SetCondition(appv1.HelmAppCondition{
@@ -299,12 +302,18 @@ func setErrorStatus(client client.StatusClient, hr *appv1.HelmRelease, err error
 		Message: err.Error(),
 	})
 
-	return updateResourceStatus(client, hr)
+	return r.updateResourceStatus(hr)
 }
 
-func updateResourceStatus(client client.StatusClient, hr *appv1.HelmRelease) error {
+func (r *ReconcileHelmRelease) updateResourceStatus(hr *appv1.HelmRelease) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return client.Status().Update(context.TODO(), hr)
+		return r.GetClient().Status().Update(context.TODO(), hr)
+	})
+}
+
+func (r *ReconcileHelmRelease) updateResource(hr *appv1.HelmRelease) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		return r.GetClient().Update(context.TODO(), hr)
 	})
 }
 
@@ -326,77 +335,40 @@ func hasBooleanAnnotation(hr *appv1.HelmRelease, annotation string) bool {
 	return value
 }
 
-// processUpgradeRelease ensures the upgradeRelease() returns or it will time it out.
-func processUpgradeRelease(client client.StatusClient, hr *appv1.HelmRelease,
-	manager helmrelease.Manager) (reconcile.Result, error) {
-	klog.V(2).Info("Processing upgrade: ", hr)
+// processUninstallRelease ensures the uninstallRelease() returns or it will timeout.
+func (r *ReconcileHelmRelease) processUninstallRelease(hr *appv1.HelmRelease,
+	manager helmoperator.Manager) (reconcile.Result, error) {
+	klog.V(2).Info("Processing uninstall release: ", hr.GetNamespace(), "/", hr.GetName())
 
 	c := make(chan HelmOperatorReconcileResult)
 
 	go func() {
-		res := upgradeRelease(client, hr, manager)
+		res := r.uninstallRelease(hr, manager)
 		c <- res
 	}()
 
-	// process the upgradeRelease() return or timeout.
-	return processHelmOperatorReconcileResult(client, hr, c)
+	// process the uninstallRelease() return or timeout.
+	return r.processHelmOperatorReconcileResult(hr, c)
 }
 
-// upgradeRelease upgrades the helm release. It should only be call when there is a HelmReleaseUpgradeForceAnnotation
-func upgradeRelease(client client.StatusClient, hr *appv1.HelmRelease,
-	manager helmrelease.Manager) HelmOperatorReconcileResult {
-	hr.Status.RemoveCondition(appv1.ConditionIrreconcilable)
+// processForceUpgradeRelease ensures the forceUpgradeRelease() returns or it will timeout.
+func (r *ReconcileHelmRelease) processForceUpgradeRelease(hr *appv1.HelmRelease,
+	manager helmoperator.Manager) (reconcile.Result, error) {
+	klog.V(2).Info("Processing force upgrade: ", hr.GetNamespace(), "/", hr.GetName())
 
-	force := hasBooleanAnnotation(hr, OperatorSDKUpgradeForceAnnotation)
-	_, upgradedRelease, err := manager.UpdateRelease(context.TODO(), release.ForceUpdate(force))
+	c := make(chan HelmOperatorReconcileResult)
 
-	if err != nil {
-		klog.Error(err, "Release failed")
-		hr.Status.SetCondition(appv1.HelmAppCondition{
-			Type:    appv1.ConditionReleaseFailed,
-			Status:  appv1.StatusTrue,
-			Reason:  appv1.ReasonUpdateError,
-			Message: err.Error(),
-		})
+	go func() {
+		res := r.forceUpgradeRelease(hr, manager)
+		c <- res
+	}()
 
-		_ = updateResourceStatus(client, hr)
-
-		horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
-
-		return *horResult
-	}
-
-	hr.Status.RemoveCondition(appv1.ConditionReleaseFailed)
-
-	klog.Info("Upgraded release", "force", force)
-	klog.V(1).Info("Config values", "values", upgradedRelease.Config)
-
-	message := ""
-
-	if upgradedRelease.Info != nil {
-		message = upgradedRelease.Info.Notes
-	}
-
-	hr.Status.SetCondition(appv1.HelmAppCondition{
-		Type:    appv1.ConditionDeployed,
-		Status:  appv1.StatusTrue,
-		Reason:  appv1.ReasonUpdateSuccessful,
-		Message: message,
-	})
-
-	hr.Status.DeployedRelease = &appv1.HelmAppRelease{
-		Name:     upgradedRelease.Name,
-		Manifest: upgradedRelease.Manifest,
-	}
-
-	err = updateResourceStatus(client, hr)
-	horResult := &HelmOperatorReconcileResult{reconcile.Result{}, err}
-
-	return *horResult
+	// process the forceUpgradeRelease() return or timeout.
+	return r.processHelmOperatorReconcileResult(hr, c)
 }
 
 // processHelmOperatorReconcileResult determines if timeout is necessary
-func processHelmOperatorReconcileResult(client client.StatusClient, hr *appv1.HelmRelease,
+func (r *ReconcileHelmRelease) processHelmOperatorReconcileResult(hr *appv1.HelmRelease,
 	c chan HelmOperatorReconcileResult) (reconcile.Result, error) {
 	select {
 	case res := <-c:
@@ -405,7 +377,7 @@ func processHelmOperatorReconcileResult(client client.StatusClient, hr *appv1.He
 		err := fmt.Errorf("timeout after 30 minutes while processing %v, check if there are any hung jobs or pods that are blocking the processing", hr)
 		klog.Error(err)
 
-		errUpdate := setErrorStatus(client, hr, err, appv1.ConditionTimedout)
+		errUpdate := r.setErrorStatus(hr, err, appv1.ConditionTimedout)
 		if errUpdate != nil {
 			return reconcile.Result{}, errUpdate
 		}

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -245,7 +245,8 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 }
 
 // processHelmOperatorReconcile ensures the helmOperatorReconcile() returns or it will timeout.
-func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Request, instance *appv1.HelmRelease, factory helmoperator.ManagerFactory) (
+func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Request,
+	instance *appv1.HelmRelease, factory helmoperator.ManagerFactory) (
 	reconcile.Result, error) {
 	klog.V(2).Info("Processing reconciliation: ", request)
 
@@ -269,7 +270,8 @@ func (r *ReconcileHelmRelease) processHelmOperatorReconcile(request reconcile.Re
 }
 
 // helmOperatorReconcile calls the Helm Operator reconcile and returns the result
-func helmOperatorReconcile(request reconcile.Request, hor helmOperatorController.HelmOperatorReconciler) HelmOperatorReconcileResult {
+func helmOperatorReconcile(request reconcile.Request,
+	hor helmOperatorController.HelmOperatorReconciler) HelmOperatorReconcileResult {
 	result, err := hor.Reconcile(request)
 	horResult := &HelmOperatorReconcileResult{result, err}
 
@@ -291,7 +293,8 @@ func containsErrorConditions(hr *appv1.HelmRelease) bool {
 	return false
 }
 
-func (r *ReconcileHelmRelease) setErrorStatus(hr *appv1.HelmRelease, err error, conditionType appv1.HelmAppConditionType) error {
+func (r *ReconcileHelmRelease) setErrorStatus(hr *appv1.HelmRelease, err error,
+	conditionType appv1.HelmAppConditionType) error {
 	klog.V(1).Info(fmt.Sprintf("Attempting to set %s/%s error status for error: %v", hr.GetNamespace(), hr.GetName(), err))
 
 	hr.Status.SetCondition(appv1.HelmAppCondition{

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -231,7 +231,6 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		!helmOperatorManager.IsUpdateRequired() &&
 		helmOperatorManager.IsInstalled() &&
 		instance.Status.DeployedRelease != nil {
-
 		// force the upgrade if HelmReleaseUpgradeForceAnnotation is set to true
 		if hasBooleanAnnotation(instance, HelmReleaseUpgradeForceAnnotation) {
 			return r.processForceUpgradeRelease(instance, helmOperatorManager)

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -499,7 +499,7 @@ func TestReconcile(t *testing.T) {
 	err = c.Get(context.TODO(), helmReleaseKey, instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	factory, err := rec.newHelmReleaseManagerFactory(instance)
+	factory, err := rec.newHelmOperatorManagerFactory(instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	nsn := types.NamespacedName{
@@ -510,7 +510,7 @@ func TestReconcile(t *testing.T) {
 	request := reconcile.Request{
 		NamespacedName: nsn,
 	}
-	_, err = rec.newHelmReleaseManager(instance, request, factory)
+	_, err = rec.newHelmOperatorManager(instance, request, factory)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// TestNewManagerShortReleaseName
@@ -546,7 +546,7 @@ func TestReconcile(t *testing.T) {
 	err = c.Get(context.TODO(), helmReleaseKey, instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	factory, err = rec.newHelmReleaseManagerFactory(instance)
+	factory, err = rec.newHelmOperatorManagerFactory(instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	nsn = types.NamespacedName{
@@ -557,7 +557,7 @@ func TestReconcile(t *testing.T) {
 	request = reconcile.Request{
 		NamespacedName: nsn,
 	}
-	_, err = rec.newHelmReleaseManager(instance, request, factory)
+	_, err = rec.newHelmOperatorManager(instance, request, factory)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// TestNewManagerValues
@@ -659,7 +659,7 @@ func Test_generateResourceListForGit(t *testing.T) {
 		},
 	}
 
-	resourceList, err := generateResourceList(mgr.GetClient(), mgr, instance)
+	resourceList, err := generateResourceList(mgr, instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(resourceList).NotTo(gomega.BeNil())
 }
@@ -709,107 +709,7 @@ func Test_generateResourceListForHelm(t *testing.T) {
 		},
 	}
 
-	resourceList, err := generateResourceList(mgr.GetClient(), mgr, instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(resourceList).NotTo(gomega.BeNil())
-}
-
-func Test_GenerateResourceListByConfigForGit(t *testing.T) {
-	defer klog.Flush()
-
-	g := gomega.NewGomegaWithT(t)
-
-	t.Log("Create manager")
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	t.Log("Testing generateResourceList For Git Source")
-
-	helmReleaseName := "example-git-succeed2"
-	instance := &appv1.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HelmRelease",
-			APIVersion: "apps.open-cluster-management.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmReleaseName,
-			Namespace: helmReleaseNS,
-		},
-		Repo: appv1.HelmReleaseRepo{
-			Source: &appv1.Source{
-				SourceType: appv1.GitSourceType,
-				Git: &appv1.Git{
-					Urls:      []string{"https://github.com/open-cluster-management/multicloud-operators-subscription-release.git"},
-					ChartPath: "test/github/subscription-release-test-3",
-				},
-			},
-			ChartName: "subscription-release-test-1",
-		},
-	}
-
-	resourceList, err := GenerateResourceListByConfig(mgr.GetClient(), mgr.GetConfig(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(resourceList).NotTo(gomega.BeNil())
-}
-
-func Test_GenerateResourceListByConfigForHelm(t *testing.T) {
-	defer klog.Flush()
-
-	g := gomega.NewGomegaWithT(t)
-
-	t.Log("Create manager")
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	t.Log("Testing generateResourceList For Helm Source")
-
-	helmReleaseName := "example-helmrepo-succeed2"
-	instance := &appv1.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HelmRelease",
-			APIVersion: "apps.open-cluster-management.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmReleaseName,
-			Namespace: helmReleaseNS,
-		},
-		Repo: appv1.HelmReleaseRepo{
-			Source: &appv1.Source{
-				SourceType: appv1.HelmRepoSourceType,
-				HelmRepo: &appv1.HelmRepo{
-					Urls: []string{
-						"https://raw.github.com/open-cluster-management/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-3-0.1.0.tgz"},
-				},
-			},
-			ChartName: "subscription-release-test-1",
-		},
-	}
-
-	resourceList, err := GenerateResourceListByConfig(mgr.GetClient(), mgr.GetConfig(), instance)
+	resourceList, err := generateResourceList(mgr, instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(resourceList).NotTo(gomega.BeNil())
 }


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

https://github.com/open-cluster-management/backlog/issues/3668

- Also removed `GenerateResourceListByConfig()` it's no longer being used.
- Moved `forceUpgradeRelease()` from controller to its helm_operator.go