### PR TITLE
Spec change to support insecureSkipVerify

### DIFF
--- a/deploy/crds/apps.open-cluster-management.io_helmreleases_crd.yaml
+++ b/deploy/crds/apps.open-cluster-management.io_helmreleases_crd.yaml
@@ -142,6 +142,9 @@ spec:
             version:
               description: Version is the chart version
               type: string
+            insecureSkipVerify:
+              description: Used to skip repo server's TLS certificate verification
+              type: boolean
           type: object
         spec: {}
         status:

--- a/pkg/apis/apps/v1/helmrelease_types.go
+++ b/pkg/apis/apps/v1/helmrelease_types.go
@@ -101,6 +101,8 @@ type HelmReleaseRepo struct {
 	SecretRef *corev1.ObjectReference `json:"secretRef,omitempty"`
 	// Configuration parameters to access the helm-repo defined in the CatalogSource
 	ConfigMapRef *corev1.ObjectReference `json:"configMapRef,omitempty"`
+	// InsecureSkipVerify is used to skip repo server's TLS certificate verification
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/apps/v1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1/zz_generated.openapi.go
@@ -118,6 +118,13 @@ func schema_pkg_apis_apps_v1_HelmReleaseRepo(ref common.ReferenceCallback) commo
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
+					"insecureSkipVerify": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InsecureSkipVerify is used to skip repo server's TLS certificate verification",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/utils/helmrepoutils.go
+++ b/pkg/utils/helmrepoutils.go
@@ -42,7 +42,7 @@ import (
 )
 
 //GetHelmRepoClient returns an *http.client to access the helm repo
-func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap) (rest.HTTPClient, error) {
+func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap, skipCertVerify bool) (rest.HTTPClient, error) {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -55,9 +55,13 @@ func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap) (res
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: false,
+			InsecureSkipVerify: skipCertVerify,
 			MinVersion:         tls.VersionTLS12,
 		},
+	}
+
+	if skipCertVerify {
+		klog.Info("repo.insecureSkipVerify=true. Skipping repo server's certificate verification.")
 	}
 
 	if configMap != nil {
@@ -77,7 +81,7 @@ func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap) (res
 				return nil, err
 			}
 
-			klog.V(5).Info("Set InsecureSkipVerify: ", b)
+			klog.Info("From config map, seting InsecureSkipVerify: ", b)
 			transport.TLSClientConfig.InsecureSkipVerify = b
 		} else {
 			klog.V(5).Info("insecureSkipVerify is not specified")
@@ -246,7 +250,7 @@ func downloadChartFromURL(configMap *corev1.ConfigMap,
 	destRepo string,
 	s *appv1.HelmRelease,
 	url string) (chartDir string, err error) {
-	chartZip, downloadErr := downloadFile(s.Namespace, configMap, url, secret, destRepo)
+	chartZip, downloadErr := downloadFile(s.Namespace, configMap, url, secret, destRepo, s.Repo.InsecureSkipVerify)
 	if downloadErr != nil {
 		klog.Error(downloadErr, " - url: ", url)
 		return "", downloadErr
@@ -287,7 +291,8 @@ func downloadChartFromURL(configMap *corev1.ConfigMap,
 func downloadFile(parentNamespace string, configMap *corev1.ConfigMap,
 	fileURL string,
 	secret *corev1.Secret,
-	chartsDir string) (string, error) {
+	chartsDir string,
+	insecureSkipVerify bool) (string, error) {
 	klog.V(4).Info("fileURL: ", fileURL)
 
 	URLP, downloadErr := url.Parse(fileURL)
@@ -311,7 +316,7 @@ func downloadFile(parentNamespace string, configMap *corev1.ConfigMap,
 	case "file":
 		downloadErr = downloadFileLocal(URLP, chartZip)
 	case "http", "https":
-		downloadErr = downloadFileHTTP(parentNamespace, configMap, fileURL, secret, chartZip)
+		downloadErr = downloadFileHTTP(parentNamespace, configMap, fileURL, secret, chartZip, insecureSkipVerify)
 	default:
 		downloadErr = fmt.Errorf("unsupported scheme %s", URLP.Scheme)
 	}
@@ -350,7 +355,8 @@ func downloadFileLocal(urlP *url.URL,
 func downloadFileHTTP(parentNamespace string, configMap *corev1.ConfigMap,
 	fileURL string,
 	secret *corev1.Secret,
-	chartZip string) error {
+	chartZip string,
+	insecureSkipVerify bool) error {
 	fileInfo, err := os.Stat(chartZip)
 	if fileInfo != nil && fileInfo.IsDir() {
 		downloadErr := fmt.Errorf("expecting chartZip to be a file but it's a directory: %s", chartZip)
@@ -360,7 +366,7 @@ func downloadFileHTTP(parentNamespace string, configMap *corev1.ConfigMap,
 	}
 
 	if os.IsNotExist(err) {
-		httpClient, downloadErr := GetHelmRepoClient(parentNamespace, configMap)
+		httpClient, downloadErr := GetHelmRepoClient(parentNamespace, configMap, insecureSkipVerify)
 		if downloadErr != nil {
 			klog.Error(downloadErr, " - Failed to create httpClient")
 			return downloadErr

--- a/pkg/utils/helmrepoutils.go
+++ b/pkg/utils/helmrepoutils.go
@@ -43,6 +43,7 @@ import (
 
 //GetHelmRepoClient returns an *http.client to access the helm repo
 func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap, skipCertVerify bool) (rest.HTTPClient, error) {
+	/* #nosec G402 */
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -55,7 +56,7 @@ func GetHelmRepoClient(parentNamespace string, configMap *corev1.ConfigMap, skip
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: skipCertVerify,
+			InsecureSkipVerify: skipCertVerify, // #nosec G402 InsecureSkipVerify conditionally
 			MinVersion:         tls.VersionTLS12,
 		},
 	}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6857

HelmRelease CRD only supports repo.configMapRef to specify insecureSkipVerify=true. We need to add insecureSkipVerify to the spec as well just to specify it without the config map. Also update the controller to look for this to skip verifying Helm server cert.