### PR TITLE
update metric ports

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -30,8 +30,8 @@ import (
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost             = "0.0.0.0"
-	metricsPort         int = 8383
-	operatorMetricsPort int = 8686
+	metricsPort         int = 8382
+	operatorMetricsPort int = 8685
 )
 
 // RunManager starts the actual manager


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Hi @xiangjingli 

I don't know how we got the initial port numbers but this is what I plan to use for all 6 of our repos. Please let me know if you have any concerns. Thanks.

```
subscription
	metricsPort         int32 = 8381
	operatorMetricsPort int32 = 8684

subscription-release
	metricsPort         int = 8382
	operatorMetricsPort int = 8685

placementrule
	metricsPort         int = 8383
	operatorMetricsPort int = 8686

channel
	metricsPort         int32 = 8384
	operatorMetricsPort int32 = 8687

deployable
	metricsPort         int32 = 8385
	operatorMetricsPort int32 = 8688

application
	metricsPort         int = 8386
	operatorMetricsPort int = 8689
```