### PR TITLE
undo last release-2.1 commit

### DIFF
--- a/pkg/controller/helmrelease/helm_operator.go
+++ b/pkg/controller/helmrelease/helm_operator.go
@@ -49,6 +49,12 @@ const (
 
 	// OperatorSDKUpgradeForceAnnotation to perform the equalivent of `helm upgrade --force`
 	OperatorSDKUpgradeForceAnnotation = "helm.operator-sdk/upgrade-force"
+
+	// HelmhResourcePolicyAnnotation see: https://helm.sh/docs/howto/charts_tips_and_tricks
+	HelmhResourcePolicyAnnotation = "helm.sh/resource-policy"
+
+	// HelmhResourcePolicyAnnotationValue see: https://helm.sh/docs/howto/charts_tips_and_tricks
+	HelmhResourcePolicyAnnotationValue = "keep"
 )
 
 /*
@@ -220,6 +226,15 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 
 			return true // resource is already deleted
 		}
+	}
+
+	ants := resource.GetAnnotations()
+	if ants != nil && ants[HelmhResourcePolicyAnnotation] == HelmhResourcePolicyAnnotationValue {
+		klog.Info("Found a resource with ", HelmhResourcePolicyAnnotation, " annotation with the value '",
+			HelmhResourcePolicyAnnotationValue, "'. Skipping resource delete for ",
+			resource.GetNamespace(), "/", resource.GetName(), " ", resource.GroupVersionKind())
+
+		return true // skip resource delete
 	}
 
 	// found the resource so it's not deleted yet

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -256,6 +256,24 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{Requeue: false}, nil
 	}
 
+	if instance.Status.DeployedRelease == nil {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " contains a nil Status.DeployedRelease")
+	} else {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " contains a populated Status.DeployedRelease")
+	}
+
+	if helmOperatorManager.IsInstalled() {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " is installed")
+	} else {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " is not installed")
+	}
+
+	if helmOperatorManager.IsUpdateRequired() {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " requires an upgrade")
+	} else {
+		klog.Info("HelmRelease ", instance.GetNamespace(), " ", instance.GetName(), " does not require an upgrade")
+	}
+
 	return r.processHelmOperatorReconcile(request, instance, helmOperatorManagerFactory)
 }
 

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -650,6 +652,68 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	time.Sleep(2 * time.Second)
+
+	t.Log("Testing Reconcile() for delete cleanup to make sure we don't delete keep Helm resource policy resources")
+
+	helmReleaseName = "nginx-ingress"
+	helmReleaseKey = types.NamespacedName{
+		Name:      helmReleaseName,
+		Namespace: helmReleaseNS,
+	}
+	instance = &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		},
+		Repo: appv1.HelmReleaseRepo{
+			Source: &appv1.Source{
+				SourceType: appv1.HelmRepoSourceType,
+				HelmRepo: &appv1.HelmRepo{
+					Urls: []string{
+						"https://raw.github.com/open-cluster-management/multicloud-operators-subscription-release/master/test/helmrepo/nginx-ingress-1.40.0_keep.tgz"},
+				},
+			},
+			ChartName: "nginx-ingress",
+		},
+	}
+
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	instanceResp = &appv1.HelmRelease{}
+	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Expect(instanceResp.Status.DeployedRelease).NotTo(gomega.BeNil())
+
+	instanceResp.Status.RemoveCondition(appv1.ConditionInitialized)
+	g.Expect(instanceResp.Status.Conditions[0].Reason).To(gomega.Equal(appv1.ReasonInstallSuccessful))
+
+	clusterRole := &rbacv1.ClusterRole{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "nginx-ingress"}, clusterRole)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(clusterRole.GetAnnotations()[HelmhResourcePolicyAnnotation]).To(gomega.Equal(HelmhResourcePolicyAnnotationValue))
+
+	err = c.Delete(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	instanceResp = &appv1.HelmRelease{}
+	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(errors.IsNotFound(err)).To(gomega.BeTrue())
+
+	clusterRole = &rbacv1.ClusterRole{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "nginx-ingress"}, clusterRole)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(clusterRole.GetAnnotations()[HelmhResourcePolicyAnnotation]).To(gomega.Equal(HelmhResourcePolicyAnnotationValue))
 }
 
 func Test_generateResourceListForGit(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

These changes are no longer necessary in release-2.1 due to a newly discover operator-sdk bug. See https://github.com/open-cluster-management/backlog/issues/7652#issuecomment-745607367 for more details.