### PR TITLE
fixed a nilpointer when trying to remove CRD from the helmreleast deployrelease manifest

### DIFF
--- a/pkg/controller/helmrelease/helmrelease_helper.go
+++ b/pkg/controller/helmrelease/helmrelease_helper.go
@@ -163,10 +163,12 @@ func (r *ReconcileHelmRelease) hackMultiClusterHubRemoveCRDReferences(hr *appv1.
 	if hr.Status.DeployedRelease == nil {
 		klog.Info("HelmRelease does not have any Status.DeployedRelease: ",
 			hr.GetNamespace(), "/", hr.GetName())
-	} else {
-		klog.Info("HelmRelease contains Status.DeployedRelease, attempting to strip CRDs from it: ",
-			hr.GetNamespace(), "/", hr.GetName())
+
+		return nil
 	}
+
+	klog.Info("HelmRelease contains Status.DeployedRelease, attempting to strip CRDs from it: ",
+		hr.GetNamespace(), "/", hr.GetName())
 
 	newManifest, changed := stripCRDs(hr.Status.DeployedRelease.Manifest)
 	if changed {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/8108

if `Status.DeployedRelease` is nil then there is no need to try to strip CRDs from the manifest because there is no manifest to strip.

Signed-off-by: Mike Ng <ming@redhat.com>