### PR TITLE
Add release-003 to testIDs pool

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -91,7 +91,7 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testIDs := []string{"release-001"}
+	testIDs := []string{"release-001", "release-003"}
 
 	for _, tID := range testIDs {
 		if err := runner(tID); err != nil {


### PR DESCRIPTION
This patch is to enable running test case release-003. 

This patch depends on https://github.com/open-cluster-management/applifecycle-backend-e2e/pull/14