### PR TITLE
skip uninstall rollback if the deployed release already populated. call sync func after delete logic which aligns with the orginal operator-sdk reconcile code

### DIFF
--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/klog"
+
 	"helm.sh/helm/v3/pkg/action"
 	cpb "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/kube"
@@ -94,6 +96,7 @@ func (m *manager) Sync(ctx context.Context) error {
 	// retried.
 	for _, rel := range releases {
 		if rel.Info != nil && rel.Info.Status != rpb.StatusDeployed {
+			klog.Info("Helm storage backend deleting: ", rel.Name, "/", rel.Version, "/", rel.Info.Status)
 			_, err := m.storageBackend.Delete(rel.Name, rel.Version)
 			if err != nil && !notFoundErr(err) {
 				return fmt.Errorf("failed to delete stale release version: %w", err)


### PR DESCRIPTION
- skip uninstall rollback in the install path if the deployed release already populated.
- call sync func after delete logic to follow operator sdk original reconcile code path https://github.com/operator-framework/operator-sdk/blob/v1.3.0/internal/helm/controller/reconcile.go
- add a log to know what sync function is deleting

Signed-off-by: Mike Ng <ming@redhat.com>