### PR TITLE
use helm functions to parse the manifest

### DIFF
--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -46,6 +46,7 @@ type Manager interface {
 	UninstallRelease(context.Context, ...UninstallOption) (*rpb.Release, error)
 	RollbackRelease(context.Context) error
 	GetDeployedRelease() (*rpb.Release, error)
+	GetActionConfig() *action.Configuration
 }
 
 type manager struct {
@@ -68,6 +69,10 @@ type manager struct {
 type InstallOption func(*action.Install) error
 type UpgradeOption func(*action.Upgrade) error
 type UninstallOption func(*action.Uninstall) error
+
+func (m manager) GetActionConfig() *action.Configuration {
+	return m.actionConfig
+}
 
 // ReleaseName returns the name of the release.
 func (m manager) ReleaseName() string {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Use Helm's internal functions to parse the manifest so that we detect the ACM CRDs that we want to remove in a more reliable manner. The previous version just treats the manifest as a yaml string with some regex which is probably not as reliable as Helm's functions when it comes to parsing.