### PR TITLE
pull changes from release-2.1 to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.15
 require (
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e // indirect
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/bugsnag/bugsnag-go v1.5.3 // indirect
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
@@ -30,7 +29,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
 	github.com/opencontainers/runc v1.0.0-rc9 // indirect
 	github.com/operator-framework/operator-lib v0.2.0
-	github.com/prometheus/common v0.10.0
 	github.com/rogpeppe/go-internal v1.5.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
@@ -43,14 +41,12 @@ require (
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed // indirect
-	gomodules.xyz/jsonpatch/v3 v3.0.1
 	google.golang.org/grpc v1.30.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	helm.sh/helm/v3 v3.4.1
 	k8s.io/api v0.19.3
-	k8s.io/apiextensions-apiserver v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/cli-runtime v0.19.3
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -1133,10 +1131,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
-gomodules.xyz/jsonpatch/v3 v3.0.1 h1:Te7hKxV52TKCbNYq3t84tzKav3xhThdvSsSp/W89IyI=
-gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
-gomodules.xyz/orderedmap v0.1.0 h1:fM/+TGh/O1KkqGR5xjTKg6bU8OKBkg7p0Y+x/J9m8Os=
-gomodules.xyz/orderedmap v0.1.0/go.mod h1:g9/TPUCm1t2gwD3j3zfV8uylyYhVdCNSi+xCEIu7yTU=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// install/upgrade/uninstall code ported from:
+// install/upgrade/uninstall code ported and modified from:
 // github.com/operator-framework/operator-sdk/internal/helm/controller/reconcile.go
-// the uninstall code has been heavily modified to include cleanup of deployed release resources
 
 //Package helmrelease controller manages the helmrelease CR
 package helmrelease
@@ -24,13 +23,13 @@ package helmrelease
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/prometheus/common/log"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +47,7 @@ import (
 
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
 	"github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/release"
+	helmoperator "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/release"
 )
 
 const (
@@ -120,10 +120,13 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 
 	err := r.GetClient().Get(context.TODO(), request.NamespacedName, instance)
 	if apierrors.IsNotFound(err) {
+		klog.Info("Ignorable error. Failed to find HelmRelease, most likely it has been uninstalled: ",
+			helmreleaseNsn(instance), " ", err)
+
 		return reconcile.Result{}, nil
 	}
 	if err != nil {
-		klog.Error(err, "Failed to lookup resource ", request.Namespace, "/", request.Name)
+		klog.Error("Failed to lookup resource ", request.Namespace, "/", request.Name, " ", err)
 		return reconcile.Result{}, err
 	}
 
@@ -133,21 +136,28 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 
 		err := yaml.Unmarshal([]byte("{\"\":\"\"}"), &spec)
 		if err != nil {
-			return reconcile.Result{}, err
+			klog.Error("Failed to unmarshal default spec: ",
+				helmreleaseNsn(instance), " ", err)
+
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 		}
 
 		instance.Spec = spec
 
 		err = r.GetClient().Update(context.TODO(), instance)
 		if err != nil {
-			return reconcile.Result{}, err
+			klog.Error("Failed to update HelmRelease with default spec: ",
+				helmreleaseNsn(instance), " ", err)
+
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 		}
 	}
 
 	// handles the download of the chart as well
 	helmOperatorManagerFactory, err := r.newHelmOperatorManagerFactory(instance)
 	if err != nil {
-		klog.Error(err, "- Failed to create new HelmOperatorManagerFactory: ", instance.GetNamespace(), "/", instance.GetName())
+		klog.Error("Failed to create new HelmOperatorManagerFactory: ",
+			helmreleaseNsn(instance), " ", err)
 
 		instance.Status.SetCondition(appv1.HelmAppCondition{
 			Type:    appv1.ConditionIrreconcilable,
@@ -156,15 +166,14 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 			Message: err.Error(),
 		})
 		_ = r.updateResourceStatus(instance)
-
-		klog.Info("Requeue HelmRelease after one minute ", instance.GetNamespace(), "/", instance.GetName())
 
 		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 	}
 
 	manager, err := r.newHelmOperatorManager(instance, request, helmOperatorManagerFactory)
 	if err != nil {
-		klog.Error(err, "- Failed to create new HelmOperatorManager: ", instance.GetNamespace(), "/", instance.GetName())
+		klog.Error("Failed to create new HelmOperatorManager: ",
+			helmreleaseNsn(instance), " ", err)
 
 		instance.Status.SetCondition(appv1.HelmAppCondition{
 			Type:    appv1.ConditionIrreconcilable,
@@ -173,144 +182,22 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 			Message: err.Error(),
 		})
 		_ = r.updateResourceStatus(instance)
-
-		klog.Info("Requeue HelmRelease after one minute ", instance.GetNamespace(), "/", instance.GetName())
 
 		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 	}
 
-	if err := manager.Sync(context.TODO()); err != nil {
-		klog.Error(err, "Failed to sync HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
+	// hack for MultiClusterHub to remove CRD outside of Helm/HelmRelease's control
+	// TODO introduce a generic annotation to trigger this feature
+	if err := r.hackMultiClusterHubRemoveCRDReferences(instance, manager.GetActionConfig()); err != nil {
+		klog.Error("Failed to hackMultiClusterHubRemoveCRDReferences: ", err)
 
-		instance.Status.SetCondition(appv1.HelmAppCondition{
-			Type:    appv1.ConditionIrreconcilable,
-			Status:  appv1.StatusTrue,
-			Reason:  appv1.ReasonReconcileError,
-			Message: err.Error(),
-		})
-		_ = r.updateResourceStatus(instance)
-
-		klog.Info("Requeue HelmRelease after one minute ", instance.GetNamespace(), "/", instance.GetName())
-
-		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		return reconcile.Result{}, err
 	}
 
 	instance.Status.RemoveCondition(appv1.ConditionIrreconcilable)
 
-	// helm uninstall
 	if instance.GetDeletionTimestamp() != nil {
-		if !contains(instance.GetFinalizers(), finalizer) {
-			klog.Info("HelmRelease is terminated, skipping reconciliation ", instance.GetNamespace(), "/", instance.GetName())
-
-			return reconcile.Result{}, nil
-		}
-
-		_, err := manager.UninstallRelease(context.TODO())
-		if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
-			klog.Error(err, "Failed to uninstall HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
-			instance.Status.SetCondition(appv1.HelmAppCondition{
-				Type:    appv1.ConditionReleaseFailed,
-				Status:  appv1.StatusTrue,
-				Reason:  appv1.ReasonUninstallError,
-				Message: err.Error(),
-			})
-			_ = r.updateResourceStatus(instance)
-			return reconcile.Result{}, err
-		}
-
-		klog.Info("Uninstalled HelmRelease ", instance.GetNamespace(), ",", instance.GetName())
-
-		// no need to check for remaining resources when there is no DeployedRelease
-		// skip ahead to removing the finalizer and let the helmrelease terminate
-		if instance.Status.DeployedRelease == nil || instance.Status.DeployedRelease.Manifest == "" {
-			controllerutil.RemoveFinalizer(instance, finalizer)
-
-			if err := r.updateResource(instance); err != nil {
-				klog.Error(err, " - Failed to strip HelmRelease uninstall finalizer ", instance.GetNamespace(), "/", instance.GetName())
-
-				return reconcile.Result{}, err
-			}
-
-			klog.Info("Removed finalizer from HelmRelease ", instance.GetNamespace(), ",", instance.GetName(), " requeue after 1 minute")
-
-			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
-		}
-
-		instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
-
-		// find all the deployed resources and check to see if they still exists
-		isFoundResource := false
-		foundResource := &unstructured.Unstructured{}
-
-		resources := releaseutil.SplitManifests(instance.Status.DeployedRelease.Manifest)
-		for _, resource := range resources {
-			var u unstructured.Unstructured
-			if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
-				klog.Error(err, " - Failed to unmarshal resource ", resource)
-
-				return reconcile.Result{}, err
-			}
-
-			gvk := u.GroupVersionKind()
-			if gvk.Empty() {
-				continue
-			}
-
-			o := &unstructured.Unstructured{}
-			o.SetName(u.GetName())
-			o.SetGroupVersionKind(u.GroupVersionKind())
-
-			if u.GetNamespace() == "" {
-				o.SetNamespace(instance.GetNamespace())
-			}
-
-			if r.isResourceDeleted(o, instance) {
-				// resource is already delete, check the next one.
-				continue
-			}
-
-			isFoundResource = true
-			foundResource = o
-		}
-
-		if isFoundResource {
-			message := "Failed to delete HelmRelease due to resource: " + foundResource.GroupVersionKind().String() + " " +
-				foundResource.GetNamespace() + "/" + foundResource.GetName() + " is not deleted yet. Checking again after one minute."
-
-			// at least one resource still exists, check again after one minute
-			instance.Status.SetCondition(appv1.HelmAppCondition{
-				Type:    appv1.ConditionReleaseFailed,
-				Status:  appv1.StatusTrue,
-				Reason:  appv1.ReasonUninstallError,
-				Message: message,
-			})
-			_ = r.updateResourceStatus(instance)
-
-			klog.Info("Requeue HelmRelease after one minute ", instance.GetNamespace(), "/", instance.GetName())
-
-			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
-		}
-
-		klog.Info("HelmRelease ", instance.GetNamespace(), "/", instance.GetName(),
-			" all DeployedRelease resources are deleted/terminating")
-
-		instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
-		instance.Status.SetCondition(appv1.HelmAppCondition{
-			Type:   appv1.ConditionDeployed,
-			Status: appv1.StatusFalse,
-			Reason: appv1.ReasonUninstallSuccessful,
-		})
-		_ = r.updateResourceStatus(instance)
-
-		controllerutil.RemoveFinalizer(instance, finalizer)
-
-		if err := r.updateResource(instance); err != nil {
-			klog.Error(err, " - Failed to strip HelmRelease uninstall finalizer ", instance.GetNamespace(), "/", instance.GetName())
-
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		return r.uninstall(instance, manager)
 	}
 
 	instance.Status.SetCondition(appv1.HelmAppCondition{
@@ -318,94 +205,41 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 		Status: appv1.StatusTrue,
 	})
 
-	// helm install
-	if !manager.IsInstalled() {
-		installedRelease, err := manager.InstallRelease(context.TODO())
-		if err != nil {
-			klog.Error(err, "Failed to install HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
-			instance.Status.SetCondition(appv1.HelmAppCondition{
-				Type:    appv1.ConditionReleaseFailed,
-				Status:  appv1.StatusTrue,
-				Reason:  appv1.ReasonInstallError,
-				Message: err.Error(),
-			})
-			_ = r.updateResourceStatus(instance)
-			return reconcile.Result{}, err
-		}
+	klog.Info("Sync Release ", helmreleaseNsn(instance))
 
-		instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+	if err := manager.Sync(context.TODO()); err != nil {
+		klog.Error("Failed to sync HelmRelease ", helmreleaseNsn(instance), " ", err)
 
-		klog.V(1).Info("Adding finalizer (", finalizer, ") to ", instance.GetNamespace(), "/", instance.GetName())
-		controllerutil.AddFinalizer(instance, finalizer)
-		if err := r.updateResource(instance); err != nil {
-			klog.Error("Failed to add uninstall finalizer to ", instance.GetNamespace(), "/", instance.GetName())
-			return reconcile.Result{}, err
-		}
-
-		klog.Info("Installed HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
-
-		message := ""
-		if installedRelease.Info != nil {
-			message = installedRelease.Info.Notes
-		}
 		instance.Status.SetCondition(appv1.HelmAppCondition{
-			Type:    appv1.ConditionDeployed,
+			Type:    appv1.ConditionIrreconcilable,
 			Status:  appv1.StatusTrue,
-			Reason:  appv1.ReasonInstallSuccessful,
-			Message: message,
+			Reason:  appv1.ReasonReconcileError,
+			Message: err.Error(),
 		})
-		instance.Status.DeployedRelease = &appv1.HelmAppRelease{
-			Name:     installedRelease.Name,
-			Manifest: installedRelease.Manifest,
-		}
-		err = r.updateResourceStatus(instance)
-		return reconcile.Result{}, err
+		_ = r.updateResourceStatus(instance)
+
+		klog.Info("Requeue HelmRelease after one minute ")
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	instance.Status.RemoveCondition(appv1.ConditionIrreconcilable)
+
+	if !manager.IsInstalled() {
+		return r.install(instance, manager)
 	}
 
 	if !contains(instance.GetFinalizers(), finalizer) {
-		klog.V(1).Info("Adding finalizer (", finalizer, ") to ", instance.GetNamespace(), "/", instance.GetName())
+		klog.V(1).Info("Adding finalizer (", finalizer, ") to ", helmreleaseNsn(instance))
 		controllerutil.AddFinalizer(instance, finalizer)
 		if err := r.updateResource(instance); err != nil {
-			klog.Error("Failed to add uninstall finalizer to ", instance.GetNamespace(), "/", instance.GetName())
-			return reconcile.Result{}, err
+			klog.Error("Failed to add uninstall finalizer to ", helmreleaseNsn(instance))
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 		}
 	}
 
-	// helm upgrade
 	if manager.IsUpgradeRequired() {
-		force := hasHelmUpgradeForceAnnotation(instance)
-		_, upgradedRelease, err := manager.UpgradeRelease(context.TODO(), release.ForceUpgrade(force))
-		if err != nil {
-			klog.Error(err, "Failed to upgrade HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
-			instance.Status.SetCondition(appv1.HelmAppCondition{
-				Type:    appv1.ConditionReleaseFailed,
-				Status:  appv1.StatusTrue,
-				Reason:  appv1.ReasonUpgradeError,
-				Message: err.Error(),
-			})
-			_ = r.updateResourceStatus(instance)
-			return reconcile.Result{}, err
-		}
-		instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
-
-		klog.Info("Upgraded HelmRelease ", "force=", force, " for ", instance.GetNamespace(), "/", instance.GetName())
-		message := ""
-		if upgradedRelease.Info != nil {
-			message = upgradedRelease.Info.Notes
-		}
-		instance.Status.SetCondition(appv1.HelmAppCondition{
-			Type:    appv1.ConditionDeployed,
-			Status:  appv1.StatusTrue,
-			Reason:  appv1.ReasonUpgradeSuccessful,
-			Message: message,
-		})
-		instance.Status.DeployedRelease = &appv1.HelmAppRelease{
-			Name:     upgradedRelease.Name,
-			Manifest: upgradedRelease.Manifest,
-		}
-		err = r.updateResourceStatus(instance)
-
-		return reconcile.Result{}, err
+		return r.upgrade(instance, manager)
 	}
 
 	// If a change is made to the CR spec that causes a release failure, a
@@ -416,41 +250,7 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 	// no longer being attempted.
 	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
 
-	// ensure the status is populated with install/upgrade reason
-	expectedRelease, err := manager.GetDeployedRelease()
-	if err != nil {
-		log.Error(err, "Failed to get deployed release for HelmRelease ", instance.GetNamespace(), "/", instance.GetName())
-		instance.Status.SetCondition(appv1.HelmAppCondition{
-			Type:    appv1.ConditionIrreconcilable,
-			Status:  appv1.StatusTrue,
-			Reason:  appv1.ReasonReconcileError,
-			Message: err.Error(),
-		})
-		_ = r.updateResourceStatus(instance)
-		return reconcile.Result{}, err
-	}
-	instance.Status.RemoveCondition(appv1.ConditionIrreconcilable)
-
-	reason := appv1.ReasonUpgradeSuccessful
-	if expectedRelease.Version == 1 {
-		reason = appv1.ReasonInstallSuccessful
-	}
-	message := ""
-	if expectedRelease.Info != nil {
-		message = expectedRelease.Info.Notes
-	}
-	instance.Status.SetCondition(appv1.HelmAppCondition{
-		Type:    appv1.ConditionDeployed,
-		Status:  appv1.StatusTrue,
-		Reason:  reason,
-		Message: message,
-	})
-	instance.Status.DeployedRelease = &appv1.HelmAppRelease{
-		Name:     expectedRelease.Name,
-		Manifest: expectedRelease.Manifest,
-	}
-	err = r.updateResourceStatus(instance)
-	return reconcile.Result{}, err
+	return r.ensureStatusReasonPopulated(instance, manager)
 }
 
 func (r ReconcileHelmRelease) updateResourceStatus(hr *appv1.HelmRelease) error {
@@ -513,8 +313,8 @@ func (r *ReconcileHelmRelease) isResourceDeleted(resource *unstructured.Unstruct
 		" ", resource.GroupVersionKind())
 
 	if err = r.GetClient().Delete(context.TODO(), resource); err != nil {
-		klog.Error(err, " - Failed to delete resource: ", resource.GetNamespace(), "/", resource.GetName(),
-			" ", resource.GroupVersionKind())
+		klog.Error("Failed to delete resource: ", resource.GetNamespace(), "/", resource.GetName(),
+			" ", resource.GroupVersionKind(), " ", err)
 	}
 
 	return false
@@ -537,4 +337,340 @@ func hasHelmUpgradeForceAnnotation(hr *appv1.HelmRelease) bool {
 		value = i
 	}
 	return value
+}
+
+func (r *ReconcileHelmRelease) install(instance *appv1.HelmRelease, manager helmoperator.Manager) (reconcile.Result, error) {
+	// If all the Helm release records are deleted, then the Helm operator will try to install the release again.
+	// In that case, if the install errors, then don't perform the uninstall rollback because it might lead to unintended data loss.
+	// See: https://github.com/operator-framework/operator-sdk/issues/4296
+	rollbackByUninstall := true
+	if instance.Status.DeployedRelease != nil {
+		klog.Info("Release is not installed but status.DeployedRelease is populated. If the install error, skip rollback(uninstall)")
+		rollbackByUninstall = false
+	}
+
+	klog.Info("Installing Release ", helmreleaseNsn(instance))
+
+	installedRelease, err := manager.InstallRelease(context.TODO())
+	if err != nil {
+		klog.Error("Failed to install HelmRelease ",
+			helmreleaseNsn(instance), " ", err)
+		instance.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonInstallError,
+			Message: err.Error(),
+		})
+		_ = r.updateResourceStatus(instance)
+
+		if rollbackByUninstall && installedRelease != nil {
+			// hack for MultiClusterHub to remove CRD outside of Helm/HelmRelease's control
+			// TODO introduce a generic annotation to trigger this feature
+			if errRemoveCRDs := r.hackMultiClusterHubRemoveCRDReferences(instance, manager.GetActionConfig()); errRemoveCRDs != nil {
+				klog.Error("Failed to hackMultiClusterHubRemoveCRDReferences: ", errRemoveCRDs)
+
+				return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+			}
+
+			klog.Info("Failed to install HelmRelease and the installedRelease response is not nil. Proceed to uninstall ",
+				helmreleaseNsn(instance))
+
+			_, errUninstall := manager.UninstallRelease(context.TODO())
+			if errUninstall != nil && !errors.Is(errUninstall, driver.ErrReleaseNotFound) {
+				klog.Error("Failed to uninstall HelmRelease for install rollback",
+					helmreleaseNsn(instance), " ", errUninstall)
+
+				instance.Status.SetCondition(appv1.HelmAppCondition{
+					Type:    appv1.ConditionReleaseFailed,
+					Status:  appv1.StatusTrue,
+					Reason:  appv1.ReasonInstallError,
+					Message: "failed installation " + err.Error() + " and failed uninstall rollback " + errUninstall.Error(),
+				})
+				_ = r.updateResourceStatus(instance)
+
+				return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+			}
+
+			klog.Info("Uninstalled Release for install failure ", helmreleaseNsn(instance))
+		}
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+
+	klog.V(1).Info("Adding finalizer (", finalizer, ") to ", helmreleaseNsn(instance))
+	controllerutil.AddFinalizer(instance, finalizer)
+	if err := r.updateResource(instance); err != nil {
+		klog.Error("Failed to add uninstall finalizer to ", helmreleaseNsn(instance), " ", err)
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	klog.Info("Installed HelmRelease ", helmreleaseNsn(instance))
+
+	message := ""
+	if installedRelease.Info != nil {
+		message = installedRelease.Info.Notes
+	}
+	instance.Status.SetCondition(appv1.HelmAppCondition{
+		Type:    appv1.ConditionDeployed,
+		Status:  appv1.StatusTrue,
+		Reason:  appv1.ReasonInstallSuccessful,
+		Message: message,
+	})
+	instance.Status.DeployedRelease = &appv1.HelmAppRelease{
+		Name:     installedRelease.Name,
+		Manifest: installedRelease.Manifest,
+	}
+	err = r.updateResourceStatus(instance)
+	if err != nil {
+		klog.Error("Failed to update resource status for HelmRelease ",
+			helmreleaseNsn(instance), " ", err)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *ReconcileHelmRelease) upgrade(instance *appv1.HelmRelease, manager helmoperator.Manager) (reconcile.Result, error) {
+	klog.Info("Upgrading Release ", helmreleaseNsn(instance))
+
+	force := hasHelmUpgradeForceAnnotation(instance)
+	_, upgradedRelease, err := manager.UpgradeRelease(context.TODO(), release.ForceUpgrade(force))
+	if err != nil {
+		klog.Error("Failed to upgrade HelmRelease ", helmreleaseNsn(instance), " ", err)
+		instance.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonUpgradeError,
+			Message: err.Error(),
+		})
+		_ = r.updateResourceStatus(instance)
+
+		// hack for MultiClusterHub to remove CRD outside of Helm/HelmRelease's control
+		// TODO introduce a generic annotation to trigger this feature
+		if errRemoveCRDs := r.hackMultiClusterHubRemoveCRDReferences(instance, manager.GetActionConfig()); errRemoveCRDs != nil {
+			klog.Error("Failed to hackMultiClusterHubRemoveCRDReferences: ", errRemoveCRDs)
+
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		}
+
+		if upgradedRelease != nil {
+			klog.Info("Failed to upgrade HelmRelease and the upgradedRelease response is not nil. Proceed to rollback ",
+				helmreleaseNsn(instance))
+
+			errRollback := manager.RollbackRelease(context.TODO())
+			if errRollback != nil && !errors.Is(errRollback, driver.ErrReleaseNotFound) {
+				klog.Error("Failed to rollback HelmRelease ",
+					helmreleaseNsn(instance), " ", err)
+
+				instance.Status.SetCondition(appv1.HelmAppCondition{
+					Type:    appv1.ConditionReleaseFailed,
+					Status:  appv1.StatusTrue,
+					Reason:  appv1.ReasonUpgradeError,
+					Message: "failed upgrade " + err.Error() + " and failed rollback: " + errRollback.Error(),
+				})
+				_ = r.updateResourceStatus(instance)
+
+				return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+			}
+
+			klog.Info("Rollbacked Release for upgrade failure ", helmreleaseNsn(instance))
+		}
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+
+	klog.Info("Upgraded HelmRelease ", "force=", force, " for ", helmreleaseNsn(instance))
+	message := ""
+	if upgradedRelease.Info != nil {
+		message = upgradedRelease.Info.Notes
+	}
+	instance.Status.SetCondition(appv1.HelmAppCondition{
+		Type:    appv1.ConditionDeployed,
+		Status:  appv1.StatusTrue,
+		Reason:  appv1.ReasonUpgradeSuccessful,
+		Message: message,
+	})
+	instance.Status.DeployedRelease = &appv1.HelmAppRelease{
+		Name:     upgradedRelease.Name,
+		Manifest: upgradedRelease.Manifest,
+	}
+	err = r.updateResourceStatus(instance)
+	if err != nil {
+		klog.Error("Failed to update resource status for HelmRelease ",
+			helmreleaseNsn(instance), " ", err)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *ReconcileHelmRelease) uninstall(instance *appv1.HelmRelease, manager helmoperator.Manager) (reconcile.Result, error) {
+	if !contains(instance.GetFinalizers(), finalizer) {
+		klog.Info("HelmRelease is terminated, skipping reconciliation ", helmreleaseNsn(instance))
+
+		return reconcile.Result{}, nil
+	}
+
+	klog.Info("Uninstalling Release ", helmreleaseNsn(instance))
+
+	_, err := manager.UninstallRelease(context.TODO())
+	if err != nil && !errors.Is(err, driver.ErrReleaseNotFound) {
+		klog.Error("Failed to uninstall HelmRelease ",
+			helmreleaseNsn(instance), " ", err)
+		instance.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonUninstallError,
+			Message: err.Error(),
+		})
+		_ = r.updateResourceStatus(instance)
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	klog.Info("Uninstalled HelmRelease ", helmreleaseNsn(instance))
+
+	// no need to check for remaining resources when there is no DeployedRelease
+	// skip ahead to removing the finalizer and let the helmrelease terminate
+	if instance.Status.DeployedRelease == nil || instance.Status.DeployedRelease.Manifest == "" {
+		controllerutil.RemoveFinalizer(instance, finalizer)
+
+		if err := r.updateResource(instance); err != nil {
+			klog.Error("Failed to strip HelmRelease uninstall finalizer ",
+				helmreleaseNsn(instance), " ", err)
+
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		}
+
+		klog.Info("Removed finalizer from HelmRelease ", helmreleaseNsn(instance), " requeue after 1 minute")
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+
+	// find all the deployed resources and check to see if they still exists
+	isFoundResource := false
+	foundResource := &unstructured.Unstructured{}
+
+	resources := releaseutil.SplitManifests(instance.Status.DeployedRelease.Manifest)
+	for _, resource := range resources {
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(resource), &u); err != nil {
+			klog.Error("Failed to unmarshal resource ", resource, " ", err)
+
+			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		}
+
+		gvk := u.GroupVersionKind()
+		if gvk.Empty() {
+			continue
+		}
+
+		o := &unstructured.Unstructured{}
+		o.SetName(u.GetName())
+		o.SetGroupVersionKind(u.GroupVersionKind())
+
+		if u.GetNamespace() == "" {
+			o.SetNamespace(instance.GetNamespace())
+		}
+
+		if r.isResourceDeleted(o, instance) {
+			// resource is already delete, check the next one.
+			continue
+		}
+
+		isFoundResource = true
+		foundResource = o
+	}
+
+	if isFoundResource {
+		message := "Failed to delete HelmRelease due to resource: " + foundResource.GroupVersionKind().String() + " " +
+			foundResource.GetNamespace() + "/" + foundResource.GetName() + " is not deleted yet. Checking again after one minute."
+
+		// at least one resource still exists, check again after one minute
+		instance.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionReleaseFailed,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonUninstallError,
+			Message: message,
+		})
+		_ = r.updateResourceStatus(instance)
+
+		klog.Info("Requeue HelmRelease after one minute ", helmreleaseNsn(instance))
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	klog.Info("HelmRelease ", helmreleaseNsn(instance),
+		" all DeployedRelease resources are deleted/terminating")
+
+	instance.Status.RemoveCondition(appv1.ConditionReleaseFailed)
+	instance.Status.SetCondition(appv1.HelmAppCondition{
+		Type:   appv1.ConditionDeployed,
+		Status: appv1.StatusFalse,
+		Reason: appv1.ReasonUninstallSuccessful,
+	})
+	_ = r.updateResourceStatus(instance)
+
+	controllerutil.RemoveFinalizer(instance, finalizer)
+
+	if err := r.updateResource(instance); err != nil {
+		klog.Error("Failed to strip HelmRelease uninstall finalizer ",
+			helmreleaseNsn(instance), " ", err)
+
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	// if everything goes well the next time the reconcile won't find the helmrelease anymore
+	// which will end the reconcile loop
+	return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+}
+
+func (r *ReconcileHelmRelease) ensureStatusReasonPopulated(
+	instance *appv1.HelmRelease, manager helmoperator.Manager) (reconcile.Result, error) {
+	expectedRelease, err := manager.GetDeployedRelease()
+	if err != nil {
+		klog.Error(err, "Failed to get deployed release for HelmRelease ",
+			helmreleaseNsn(instance))
+		instance.Status.SetCondition(appv1.HelmAppCondition{
+			Type:    appv1.ConditionIrreconcilable,
+			Status:  appv1.StatusTrue,
+			Reason:  appv1.ReasonReconcileError,
+			Message: err.Error(),
+		})
+		_ = r.updateResourceStatus(instance)
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+	instance.Status.RemoveCondition(appv1.ConditionIrreconcilable)
+
+	reason := appv1.ReasonUpgradeSuccessful
+	if expectedRelease.Version == 1 {
+		reason = appv1.ReasonInstallSuccessful
+	}
+	message := ""
+	if expectedRelease.Info != nil {
+		message = expectedRelease.Info.Notes
+	}
+	instance.Status.SetCondition(appv1.HelmAppCondition{
+		Type:    appv1.ConditionDeployed,
+		Status:  appv1.StatusTrue,
+		Reason:  reason,
+		Message: message,
+	})
+	instance.Status.DeployedRelease = &appv1.HelmAppRelease{
+		Name:     expectedRelease.Name,
+		Manifest: expectedRelease.Manifest,
+	}
+	err = r.updateResourceStatus(instance)
+	if err != nil {
+		klog.Error("Failed to update resource status for HelmRelease ",
+			helmreleaseNsn(instance), " ", err)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func helmreleaseNsn(hr *appv1.HelmRelease) string {
+	return fmt.Sprintf("%s/%s", hr.GetNamespace(), hr.GetName())
 }

--- a/pkg/controller/helmrelease/helmrelease_helper.go
+++ b/pkg/controller/helmrelease/helmrelease_helper.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2020 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helmrelease
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/action"
+
+	appv1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+
+	"helm.sh/helm/v3/pkg/chartutil"
+	rspb "helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/releaseutil"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+// nameFilter filters a set of Helm storage releases by name.
+func nameFilter(name string) releaseutil.FilterFunc {
+	return releaseutil.FilterFunc(func(rls *rspb.Release) bool {
+		if rls == nil {
+			return true
+		}
+		return rls.Name == name
+	})
+}
+
+// determines if this HelmRelease is owned by Subscription which is owned by MultiClusterHub
+func (r *ReconcileHelmRelease) isMultiClusterHubOwnedResource(hr *appv1.HelmRelease) (bool, error) {
+	klog.V(3).Info("Running isMultiClusterHubOwnedResource on ", hr.GetNamespace(), "/", hr.GetName())
+
+	if hr.OwnerReferences == nil {
+		return false, nil
+	}
+
+	for _, hrOwner := range hr.OwnerReferences {
+		if hrOwner.Kind == "Subscription" {
+			appsubGVK := schema.FromAPIVersionAndKind(hrOwner.APIVersion, hrOwner.Kind)
+			appsubNsn := types.NamespacedName{Namespace: hr.GetNamespace(), Name: hrOwner.Name}
+
+			appsub := &unstructured.Unstructured{}
+			appsub.SetGroupVersionKind(appsubGVK)
+			appsub.SetNamespace(appsubNsn.Namespace)
+			appsub.SetName(appsubNsn.Name)
+
+			err := r.GetClient().Get(context.TODO(), appsubNsn, appsub)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					klog.Info("Failed to find the parent (already deleted?), won't be able to determine if it's an ACM's HelmRelease: ",
+						appsubNsn, " ", err)
+
+					return false, nil
+				}
+
+				klog.Error("Failed to lookup HelmRelease's parent Subscription: ", appsubNsn, " ", err)
+
+				return false, err
+			}
+
+			if appsub.GetOwnerReferences() != nil {
+				for _, appsubOwner := range appsub.GetOwnerReferences() {
+					if appsubOwner.Kind == "MultiClusterHub" &&
+						strings.Contains(appsubOwner.APIVersion, "open-cluster-management") {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// Remove CRD references from Helm storage and HelmRelease's Status.DeployedRelease.Manifest
+// TODO add an annotation to trigger this feature instead of triggering on MultiClusterHub owned resource
+func (r *ReconcileHelmRelease) hackMultiClusterHubRemoveCRDReferences(hr *appv1.HelmRelease, c *action.Configuration) error {
+	klog.V(3).Info("Running hackMultiClusterHubRemoveCRDReferences on ", hr.GetNamespace(), "/", hr.GetName())
+
+	isOwnedByMCH, err := r.isMultiClusterHubOwnedResource(hr)
+	if err != nil {
+		klog.Error("Failed to determine if HelmRelease is owned a MultiClusterHub resource: ",
+			hr.GetNamespace(), "/", hr.GetName())
+
+		return err
+	}
+
+	if !isOwnedByMCH {
+		klog.Info("HelmRelease is not owned by a MultiClusterHub resource: ",
+			hr.GetNamespace(), "/", hr.GetName())
+
+		return nil
+	}
+
+	klog.Info("HelmRelease is owned by a MultiClusterHub resource proceed with the removal of all CRD references: ",
+		hr.GetNamespace(), "/", hr.GetName())
+
+	clientv1, err := v1.NewForConfig(r.GetConfig())
+	if err != nil {
+		klog.Error("Failed create client for HelmRelease: ", hr.GetNamespace(), "/", hr.GetName())
+
+		return err
+	}
+
+	storageBackend := storage.Init(driver.NewSecrets(clientv1.Secrets(hr.GetNamespace())))
+
+	storageReleases, err := storageBackend.List(
+		func(rls *rspb.Release) bool {
+			return nameFilter(hr.GetName()).Check(rls)
+		})
+	if err != nil {
+		klog.Error("Failed list all storage releases for HelmRelease: ", hr.GetNamespace(), "/", hr.GetName())
+
+		return err
+	}
+
+	if storageReleases == nil {
+		klog.Info("HelmRelease does not have any matching Helm storage releases: ",
+			hr.GetNamespace(), "/", hr.GetName())
+	} else {
+		klog.Info("HelmRelease contains storage releases, attempting to strip CRDs from them: ",
+			hr.GetNamespace(), "/", hr.GetName())
+	}
+
+	for _, storageRelease := range storageReleases {
+		klog.Info("Release: ", storageRelease.Name)
+
+		if storageRelease.Info != nil {
+			klog.Info("Release: ", storageRelease.Name, " Status: ", storageRelease.Info.Status.String())
+		}
+
+		newManifest, changed, err := stripCRDs(storageRelease.Manifest, c)
+		if err != nil {
+			return err
+		}
+		if changed {
+			klog.Info("Release: ", storageRelease.Name, " needs updating")
+
+			storageRelease.Manifest = newManifest
+
+			err = storageBackend.Update(storageRelease)
+			if err != nil {
+				klog.Error("Failed update storage release for HelmRelease: ", hr.GetNamespace(), "/", hr.GetName())
+
+				return err
+			}
+
+		} else {
+			klog.Info("Release: ", storageRelease.Name, " is unchanged")
+		}
+	}
+
+	if hr.Status.DeployedRelease == nil {
+		klog.Info("HelmRelease does not have any Status.DeployedRelease: ",
+			hr.GetNamespace(), "/", hr.GetName())
+
+		return nil
+	}
+
+	klog.Info("HelmRelease contains Status.DeployedRelease, attempting to strip CRDs from it: ",
+		hr.GetNamespace(), "/", hr.GetName())
+
+	newManifest, changed, err := stripCRDs(hr.Status.DeployedRelease.Manifest, c)
+	if err != nil {
+		return err
+	}
+	if changed {
+		klog.Info("Status release: ", hr.GetName(), " needs updating")
+
+		hr.Status.DeployedRelease.Manifest = newManifest
+
+		err = r.updateResourceStatus(hr)
+		if err != nil {
+			klog.Error("Failed to update Status.DeployedRelease.Manifest for HelmRelease: ",
+				hr.GetNamespace(), "/", hr.GetName())
+
+			return err
+		}
+
+	} else {
+		klog.Info("Status release: ", hr.GetName(), " is unchanged")
+	}
+
+	return nil
+}
+
+func stripCRDs(bigFile string, c *action.Configuration) (string, bool, error) {
+	changed := false
+
+	caps, err := getCapabilities(c)
+	if err != nil {
+		return "", false, err
+	}
+
+	manifests := releaseutil.SplitManifests(bigFile)
+	_, files, err := releaseutil.SortManifests(manifests, caps.APIVersions, releaseutil.InstallOrder)
+	if err != nil {
+		return "", false, fmt.Errorf("corrupted release record. You must manually delete the resources %w", err)
+	}
+
+	var builder strings.Builder
+	for _, file := range files {
+		if file.Head != nil && file.Head.Kind == "CustomResourceDefinition" {
+			if file.Head.Metadata != nil {
+				klog.Info("CRD detected: ", file.Head.Metadata.Name)
+			}
+			changed = true
+		} else {
+			builder.WriteString("\n---\n" + file.Content)
+		}
+	}
+
+	return builder.String(), changed, nil
+}
+
+// capabilities builds a Capabilities from discovery information. Took from https://github.com/helm/helm/blob/v3.4.2/pkg/action/action.go
+func getCapabilities(c *action.Configuration) (*chartutil.Capabilities, error) {
+	if c.Capabilities != nil {
+		return c.Capabilities, nil
+	}
+	dc, err := c.RESTClientGetter.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	// force a discovery cache invalidation to always fetch the latest server version/capabilities.
+	dc.Invalidate()
+	kubeVersion, err := dc.ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	// Issue #6361:
+	// Client-Go emits an error when an API service is registered but unimplemented.
+	// We trap that error here and print a warning. But since the discovery client continues
+	// building the API object, it is correctly populated with all valid APIs.
+	// See https://github.com/kubernetes/kubernetes/issues/72051#issuecomment-521157642
+	apiVersions, err := action.GetVersionSet(dc)
+	if err != nil {
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			klog.Info("WARNING: The Kubernetes server has an orphaned API service. Server reports: %s", err)
+			klog.Info("WARNING: To fix this, kubectl delete apiservice <service-name>")
+		} else {
+			return nil, err
+		}
+	}
+
+	c.Capabilities = &chartutil.Capabilities{
+		APIVersions: apiVersions,
+		KubeVersion: chartutil.KubeVersion{
+			Version: kubeVersion.GitVersion,
+			Major:   kubeVersion.Major,
+			Minor:   kubeVersion.Minor,
+		},
+	}
+	return c.Capabilities, nil
+}

--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -13,31 +13,23 @@
 // limitations under the License.
 
 // copied and modified from github.com/operator-framework/operator-sdk/internal/helm/release
-// merged changes from https://github.com/operator-framework/operator-sdk/pull/3431
 
 package release
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	jsonpatch "gomodules.xyz/jsonpatch/v3"
+	"k8s.io/klog"
+
 	"helm.sh/helm/v3/pkg/action"
 	cpb "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/kube"
-	helmkube "helm.sh/helm/v3/pkg/kube"
 	rpb "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime"
-	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/cli-runtime/pkg/resource"
 
 	appv1 "github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/apis/apps/v1"
 )
@@ -52,7 +44,9 @@ type Manager interface {
 	InstallRelease(context.Context, ...InstallOption) (*rpb.Release, error)
 	UpgradeRelease(context.Context, ...UpgradeOption) (*rpb.Release, *rpb.Release, error)
 	UninstallRelease(context.Context, ...UninstallOption) (*rpb.Release, error)
+	RollbackRelease(context.Context) error
 	GetDeployedRelease() (*rpb.Release, error)
+	GetActionConfig() *action.Configuration
 }
 
 type manager struct {
@@ -75,6 +69,10 @@ type manager struct {
 type InstallOption func(*action.Install) error
 type UpgradeOption func(*action.Upgrade) error
 type UninstallOption func(*action.Uninstall) error
+
+func (m manager) GetActionConfig() *action.Configuration {
+	return m.actionConfig
+}
 
 // ReleaseName returns the name of the release.
 func (m manager) ReleaseName() string {
@@ -103,6 +101,7 @@ func (m *manager) Sync(ctx context.Context) error {
 	// retried.
 	for _, rel := range releases {
 		if rel.Info != nil && rel.Info.Status != rpb.StatusDeployed {
+			klog.Info("Helm storage backend deleting: ", rel.Name, "/", rel.Version, "/", rel.Info.Status)
 			_, err := m.storageBackend.Delete(rel.Name, rel.Version)
 			if err != nil && !notFoundErr(err) {
 				return fmt.Errorf("failed to delete stale release version: %w", err)
@@ -167,28 +166,7 @@ func (m manager) InstallRelease(ctx context.Context, opts ...InstallOption) (*rp
 		}
 	}
 
-	installedRelease, err := install.Run(m.chart, m.values)
-	if err != nil {
-		// Workaround for helm/helm#3338
-		if installedRelease != nil {
-			uninstall := action.NewUninstall(m.actionConfig)
-			_, uninstallErr := uninstall.Run(m.releaseName)
-
-			// In certain cases, InstallRelease will return a partial release in
-			// the response even when it doesn't record the release in its release
-			// store (e.g. when there is an error rendering the release manifest).
-			// In that case the rollback will fail with a not found error because
-			// there was nothing to rollback.
-			//
-			// Only log a message about a rollback failure if the failure was caused
-			// by something other than the release not being found.
-			if uninstallErr != nil && !notFoundErr(uninstallErr) {
-				return nil, fmt.Errorf("failed installation (%s) and failed rollback: %w", err, uninstallErr)
-			}
-		}
-		return nil, fmt.Errorf("failed to install release: %w", err)
-	}
-	return installedRelease, nil
+	return install.Run(m.chart, m.values)
 }
 
 func ForceUpgrade(force bool) UpgradeOption {
@@ -210,91 +188,9 @@ func (m manager) UpgradeRelease(ctx context.Context, opts ...UpgradeOption) (*rp
 
 	upgradedRelease, err := upgrade.Run(m.releaseName, m.chart, m.values)
 	if err != nil {
-		// Workaround for helm/helm#3338
-		if upgradedRelease != nil {
-			rollback := action.NewRollback(m.actionConfig)
-			rollback.Force = true
-
-			// As of Helm 2.13, if UpgradeRelease returns a non-nil release, that
-			// means the release was also recorded in the release store.
-			// Therefore, we should perform the rollback when we have a non-nil
-			// release. Any rollback error here would be unexpected, so always
-			// log both the upgrade and rollback errors.
-			rollbackErr := rollback.Run(m.releaseName)
-			if rollbackErr != nil {
-				return nil, nil, fmt.Errorf("failed upgrade (%s) and failed rollback: %w", err, rollbackErr)
-			}
-		}
-		return nil, nil, fmt.Errorf("failed to upgrade release: %w", err)
+		return nil, nil, err
 	}
 	return m.deployedRelease, upgradedRelease, err
-}
-
-func createPatch(existing runtime.Object, expected *resource.Info) ([]byte, apitypes.PatchType, error) {
-	existingJSON, err := json.Marshal(existing)
-	if err != nil {
-		return nil, apitypes.StrategicMergePatchType, err
-	}
-	expectedJSON, err := json.Marshal(expected.Object)
-	if err != nil {
-		return nil, apitypes.StrategicMergePatchType, err
-	}
-
-	// Get a versioned object
-	versionedObject := helmkube.AsVersioned(expected)
-
-	// Unstructured objects, such as CRDs, may not have an not registered error
-	// returned from ConvertToVersion. Anything that's unstructured should
-	// use the jsonpatch.CreateMergePatch. Strategic Merge Patch is not supported
-	// on objects like CRDs.
-	_, isUnstructured := versionedObject.(runtime.Unstructured)
-
-	// On newer K8s versions, CRDs aren't unstructured but have a dedicated type
-	_, isV1CRD := versionedObject.(*apiextv1.CustomResourceDefinition)
-	_, isV1beta1CRD := versionedObject.(*apiextv1beta1.CustomResourceDefinition)
-	isCRD := isV1CRD || isV1beta1CRD
-
-	if isUnstructured || isCRD {
-		// fall back to generic JSON merge patch
-		patch, err := createJSONMergePatch(existingJSON, expectedJSON)
-		return patch, apitypes.JSONPatchType, err
-	}
-
-	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(versionedObject)
-	if err != nil {
-		return nil, apitypes.StrategicMergePatchType, err
-	}
-
-	patch, err := strategicpatch.CreateThreeWayMergePatch(expectedJSON, expectedJSON, existingJSON, patchMeta, true)
-	return patch, apitypes.StrategicMergePatchType, err
-}
-
-func createJSONMergePatch(existingJSON, expectedJSON []byte) ([]byte, error) {
-	ops, err := jsonpatch.CreatePatch(existingJSON, expectedJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	// We ignore the "remove" operations from the full patch because they are
-	// fields added by Kubernetes or by the user after the existing release
-	// resource has been applied. The goal for this patch is to make sure that
-	// the fields managed by the Helm chart are applied.
-	// All "add" operations without a value (null) can be ignored
-	patchOps := make([]jsonpatch.JsonPatchOperation, 0)
-	for _, op := range ops {
-		if op.Operation != "remove" && !(op.Operation == "add" && op.Value == nil) {
-			patchOps = append(patchOps, op)
-		}
-	}
-
-	// If there are no patch operations, return nil. Callers are expected
-	// to check for a nil response and skip the patch operation to avoid
-	// unnecessary chatter with the API server.
-	if len(patchOps) == 0 {
-		return nil, nil
-	}
-
-	return json.Marshal(patchOps)
 }
 
 // UninstallRelease performs a Helm release uninstall.
@@ -311,9 +207,17 @@ func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) 
 		}
 	}
 	uninstallResponse, err := uninstall.Run(m.releaseName)
-	if err != nil {
+	if uninstallResponse == nil {
 		return nil, err
 	}
 
-	return uninstallResponse.Release, nil
+	return uninstallResponse.Release, err
+}
+
+// RollbackRelease performs a Helm release rollback.
+func (m manager) RollbackRelease(ctx context.Context) error {
+	rollback := action.NewRollback(m.actionConfig)
+	rollback.Force = true
+
+	return rollback.Run(m.releaseName)
 }

--- a/pkg/release/manager_test.go
+++ b/pkg/release/manager_test.go
@@ -17,18 +17,11 @@
 package release
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/resource"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func newTestUnstructured(containers []interface{}) *unstructured.Unstructured {
@@ -62,156 +55,5 @@ func newTestDeployment(containers []v1.Container) *appsv1.Deployment {
 				},
 			},
 		},
-	}
-}
-
-func TestManagerGenerateStrategicMergePatch(t *testing.T) {
-
-	tests := []struct {
-		o1        runtime.Object
-		o2        runtime.Object
-		patch     string
-		patchType apitypes.PatchType
-	}{
-		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-				map[string]interface{}{
-					"name": "test2",
-				},
-			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-			}),
-			patch:     ``,
-			patchType: apitypes.JSONPatchType,
-		},
-		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-				map[string]interface{}{
-					"name": "test2",
-				},
-			}),
-			patch:     `[{"op":"add","path":"/spec/template/spec/containers/1","value":{"name":"test2"}}]`,
-			patchType: apitypes.JSONPatchType,
-		},
-		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-					"test": nil,
-				},
-			}),
-			patch:     ``,
-			patchType: apitypes.JSONPatchType,
-		},
-		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test1",
-				},
-			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
-					"name": "test2",
-				},
-			}),
-			patch:     `[{"op":"replace","path":"/spec/template/spec/containers/0/name","value":"test2"}]`,
-			patchType: apitypes.JSONPatchType,
-		},
-		{
-			o1: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-				{Name: "test2"},
-			}),
-			o2: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"}]}}}}`,
-			patchType: apitypes.StrategicMergePatchType,
-		},
-		{
-			o1: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-			}),
-			o2: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-				{Name: "test2"},
-			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"},{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`,
-			patchType: apitypes.StrategicMergePatchType,
-		},
-		{
-			o1: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-			}),
-			o2: newTestDeployment([]v1.Container{
-				{Name: "test1", LivenessProbe: nil},
-			}),
-			patch:     `{}`,
-			patchType: apitypes.StrategicMergePatchType,
-		},
-		{
-			o1: newTestDeployment([]v1.Container{
-				{Name: "test1"},
-			}),
-			o2: newTestDeployment([]v1.Container{
-				{Name: "test2"},
-			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`,
-			patchType: apitypes.StrategicMergePatchType,
-		},
-		{
-			o1: &appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						"testannotation": "testvalue",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{},
-			},
-			o2: &appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "ns",
-				},
-				Spec: appsv1.DeploymentSpec{},
-			},
-			patch:     `{}`,
-			patchType: apitypes.StrategicMergePatchType,
-		},
-	}
-
-	for _, test := range tests {
-
-		o2Info := &resource.Info{
-			Object: test.o2,
-		}
-
-		diff, patchType, err := createPatch(test.o1, o2Info)
-		assert.NoError(t, err)
-		assert.Equal(t, test.patchType, patchType)
-		assert.Equal(t, test.patch, string(diff))
 	}
 }


### PR DESCRIPTION
for https://github.com/open-cluster-management/backlog/issues/8261
- added strip crds if the helmrelease came from ACM
- skip uninstall rollback if the deployedrelease already exists
- call manager sync after Helm delete logic

these PRs are pulled over
https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/130
https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/131
https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/133
https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/134
https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/135

I think besides some dependencies differences and the `InsecureSkipVerify` in the spec. The release-2.1 and master should be the same. 

Signed-off-by: Mike Ng <ming@redhat.com>