### PR TITLE
various enhancements to helmrelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 
 ## References
 
-- Access the following multicloud-operators repositories:
+- Access the following multicloud-operators repositories: 
 
     - [multicloud-operators-application](https://github.com/open-cluster-management/multicloud-operators-application)
     - [multicloud-operators-channel](https://github.com/open-cluster-management/multicloud-operators-channel)

--- a/pkg/apis/apps/v1/helmrelease_types.go
+++ b/pkg/apis/apps/v1/helmrelease_types.go
@@ -97,6 +97,8 @@ type HelmReleaseRepo struct {
 	ChartName string `json:"chartName,omitempty"`
 	// Version is the chart version
 	Version string `json:"version,omitempty"`
+	// Digest is the helm repo chart digest
+	Digest string `json:"digest,omitempty"`
 	// Secret to use to access the helm-repo defined in the CatalogSource.
 	SecretRef *corev1.ObjectReference `json:"secretRef,omitempty"`
 	// Configuration parameters to access the helm-repo defined in the CatalogSource

--- a/pkg/apis/apps/v1/zz_generated.openapi.go
+++ b/pkg/apis/apps/v1/zz_generated.openapi.go
@@ -106,6 +106,13 @@ func schema_pkg_apis_apps_v1_HelmReleaseRepo(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"digest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Digest is the helm repo chart digest",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Secret to use to access the helm-repo defined in the CatalogSource.",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// copied from github.com/operator-framework/operator-sdk/internal/helm/client
-
 package client
 
 import (
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/open-cluster-management/multicloud-operators-subscription-release/pkg/internal/util/k8sutil"
 	"github.com/operator-framework/operator-lib/handler"
@@ -146,7 +145,9 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 			return err
 		}
 
-		if useOwnerRef {
+		// If the resource contains the Helm resource-policy keep annotation, then do not add
+		// the owner reference. So when the CR is deleted, Kubernetes won't GCs the resource.
+		if useOwnerRef && !containsResourcePolicyKeep(u.GetAnnotations()) {
 			ownerRef := metav1.NewControllerRef(c.owner, c.owner.GroupVersionKind())
 			u.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
 		} else {
@@ -161,4 +162,16 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 		return nil, err
 	}
 	return resourceList, nil
+}
+
+func containsResourcePolicyKeep(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+	resourcePolicyType, ok := annotations[kube.ResourcePolicyAnno]
+	if !ok {
+		return false
+	}
+	resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
+	return resourcePolicyType == kube.KeepPolicy
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/kube"
+)
+
+func TestContainsResourcePolicyKeep(t *testing.T) {
+	tests := []struct {
+		input       map[string]string
+		expectedVal bool
+		expectedOut string
+		name        string
+	}{
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: kube.KeepPolicy,
+			},
+			expectedVal: true,
+			name:        "base case true",
+		},
+		{
+			input: map[string]string{
+				"not-" + kube.ResourcePolicyAnno: kube.KeepPolicy,
+			},
+			expectedVal: false,
+			name:        "base case annotation false",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: "not-" + kube.KeepPolicy,
+			},
+			expectedVal: false,
+			name:        "base case value false",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: strings.ToUpper(kube.KeepPolicy),
+			},
+			expectedVal: true,
+			name:        "true with upper case",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: " " + kube.KeepPolicy + "  ",
+			},
+			expectedVal: true,
+			name:        "true with spaces",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: " " + strings.ToUpper(kube.KeepPolicy) + "  ",
+			},
+			expectedVal: true,
+			name:        "true with upper case and spaces",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedVal, containsResourcePolicyKeep(test.input), test.name)
+	}
+}

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -131,7 +131,7 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// setting the nil spec to "":"" allows helmrelease to reconcile with default chart values.
-	if instance.Spec == nil {
+	if instance.Spec == nil && instance.GetDeletionTimestamp() == nil {
 		spec := make(map[string]interface{})
 
 		err := yaml.Unmarshal([]byte("{\"\":\"\"}"), &spec)
@@ -551,7 +551,12 @@ func (r *ReconcileHelmRelease) uninstall(instance *appv1.HelmRelease, manager he
 				klog.Error("Errors caught while trying to delete resources ", joinErrors(errs))
 			}
 
-			message := "Failed to delete HelmRelease due to resource: " +
+			gvk := ""
+			if resource.Mapping != nil {
+				gvk = resource.Mapping.GroupVersionKind.String()
+			}
+
+			message := "Failed to delete HelmRelease due to resource: " + gvk + " " +
 				resource.Namespace + "/" + resource.Name +
 				" is not deleted yet. Checking again after one minute."
 			klog.Error(message)

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -189,6 +189,11 @@ func TestReconcile(t *testing.T) {
 	g.Expect(len(instanceResp.Status.Conditions)).To(gomega.Equal(2))
 	g.Expect(instanceResp.Status.Conditions[1].Reason).To(gomega.Equal(appv1.ReasonUpgradeSuccessful))
 
+	instanceResp.Repo.Source.GitHub.Urls[0] = "https://github.com/open-cluster-management/multicloud-operators-subscription-release-wrongurl.git"
+
+	err = c.Delete(context.TODO(), instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
 	//
 	//Github failed
 	//
@@ -332,6 +337,11 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(instanceResp.Status.DeployedRelease).NotTo(gomega.BeNil())
 	g.Expect(instanceResp.Repo.Version).Should(gomega.Equal("3-0.1.0"))
+
+	instanceResp.Repo.Source.HelmRepo.Urls[0] = "https://github.com/open-cluster-management/multicloud-operators-subscription-release-wrongurl"
+
+	err = c.Delete(context.TODO(), instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	//
 	//helmRepo failure
@@ -650,6 +660,71 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	time.Sleep(2 * time.Second)
+
+	t.Log("helmrepo keep test")
+
+	helmReleaseName = "example-helmrepo-keep"
+	helmReleaseKey = types.NamespacedName{
+		Name:      helmReleaseName,
+		Namespace: helmReleaseNS,
+	}
+	instance = &appv1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "apps.open-cluster-management.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		},
+		Repo: appv1.HelmReleaseRepo{
+			Source: &appv1.Source{
+				SourceType: appv1.HelmRepoSourceType,
+				HelmRepo: &appv1.HelmRepo{
+					Urls: []string{
+						"https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/master/test/helmrepo/nginx-ingress-1.40.0_keep.tgz"},
+				},
+			},
+			ChartName: "nginx-ingress",
+		},
+	}
+
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	instanceResp = &appv1.HelmRelease{}
+	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	clusterRoleKey := types.NamespacedName{
+		Name: helmReleaseName + "-" + "nginx-ingress",
+	}
+	roleKey := types.NamespacedName{
+		Name:      helmReleaseName + "-" + "nginx-ingress",
+		Namespace: helmReleaseNS,
+	}
+	clusterRole := &v1.ClusterRole{}
+	err = c.Get(context.TODO(), clusterRoleKey, clusterRole)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	role := &v1.Role{}
+	err = c.Get(context.TODO(), roleKey, role)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = c.Delete(context.TODO(), instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	err = c.Get(context.TODO(), clusterRoleKey, clusterRole)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = c.Get(context.TODO(), roleKey, role)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 func Test_generateResourceListForGit(t *testing.T) {
@@ -750,98 +825,4 @@ func Test_generateResourceListForHelm(t *testing.T) {
 	resourceList, err := generateResourceList(mgr, instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(resourceList).NotTo(gomega.BeNil())
-}
-
-func TestDeleteKeepCleanup(t *testing.T) {
-	defer klog.Flush()
-
-	g := gomega.NewGomegaWithT(t)
-
-	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-	// channel when it is finished.
-
-	t.Log("Create manager")
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	c := mgr.GetClient()
-
-	t.Log("Setup test reconcile")
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	t.Log("helmrepo keep test")
-
-	helmReleaseName := "example-helmrepo-keep"
-	helmReleaseKey := types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}
-	instance := &appv1.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HelmRelease",
-			APIVersion: "apps.open-cluster-management.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmReleaseName,
-			Namespace: helmReleaseNS,
-		},
-		Repo: appv1.HelmReleaseRepo{
-			Source: &appv1.Source{
-				SourceType: appv1.HelmRepoSourceType,
-				HelmRepo: &appv1.HelmRepo{
-					Urls: []string{
-						"https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/master/test/helmrepo/nginx-ingress-1.40.0_keep.tgz"},
-				},
-			},
-			ChartName: "nginx-ingress",
-		},
-	}
-
-	err = c.Create(context.TODO(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(4 * time.Second)
-
-	instanceResp := &appv1.HelmRelease{}
-	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(4 * time.Second)
-
-	clusterRoleKey := types.NamespacedName{
-		Name: helmReleaseName + "-" + "nginx-ingress",
-	}
-	roleKey := types.NamespacedName{
-		Name:      helmReleaseName + "-" + "nginx-ingress",
-		Namespace: helmReleaseNS,
-	}
-	clusterRole := &v1.ClusterRole{}
-	err = c.Get(context.TODO(), clusterRoleKey, clusterRole)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	role := &v1.Role{}
-	err = c.Get(context.TODO(), roleKey, role)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = c.Delete(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(4 * time.Second)
-
-	err = c.Get(context.TODO(), clusterRoleKey, clusterRole)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = c.Get(context.TODO(), roleKey, role)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/pkg/controller/helmrelease/helmreleasemgr.go
+++ b/pkg/controller/helmrelease/helmreleasemgr.go
@@ -48,6 +48,10 @@ import (
 //newHelmOperatorManagerFactory create a new manager returns a helmManagerFactory
 func (r ReconcileHelmRelease) newHelmOperatorManagerFactory(
 	s *appv1.HelmRelease) (helmoperator.ManagerFactory, error) {
+	if s.GetDeletionTimestamp() != nil {
+		return helmoperator.NewManagerFactory(r.Manager, ""), nil
+	}
+
 	chartDir, err := downloadChart(r.GetClient(), s)
 	if err != nil {
 		klog.Error(err, " - Failed to download the chart")

--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -195,17 +195,13 @@ func (m manager) UpgradeRelease(ctx context.Context, opts ...UpgradeOption) (*rp
 
 // UninstallRelease performs a Helm release uninstall.
 func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) (*rpb.Release, error) {
-	// Get history of this release
-	if _, err := m.storageBackend.History(m.releaseName); err != nil {
-		return nil, fmt.Errorf("failed to get release history: %w", err)
-	}
-
 	uninstall := action.NewUninstall(m.actionConfig)
 	for _, o := range opts {
 		if err := o(uninstall); err != nil {
 			return nil, fmt.Errorf("failed to apply uninstall option: %w", err)
 		}
 	}
+
 	uninstallResponse, err := uninstall.Run(m.releaseName)
 	if uninstallResponse == nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

- HelmRelease delete shouldn't need to download charts to work.
- pull operator-sdk upstream fixes
- added `digest` (to be populated by the appsub side similar to version)

part 1 of https://github.com/open-cluster-management/backlog/issues/8603 