### PR TITLE
HelmRelease with spec change YAML

### DIFF
--- a/examples/test-guestbook-spec-change.yaml
+++ b/examples/test-guestbook-spec-change.yaml
@@ -13,10 +13,10 @@ repo:
   chartName: nginx-chart
   source:
     github:
-      branch: gh-pages
-      chartPath: nginx-chart
+      branch: main
+      chartPath: /test/github/nginx-chart
       urls:
-        - https://github.com/pezhang/helm-release-API-test.git
+        - https://github.com/open-cluster-management/multicloud-operators-subscription-release.git
     type: git
   version: 0.1.0
 spec:

--- a/examples/test-guestbook-spec-change.yaml
+++ b/examples/test-guestbook-spec-change.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helmrelease-spec-test
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-spec-test
+repo:
+  chartName: nginx-chart
+  source:
+    github:
+      branch: gh-pages
+      chartPath: nginx-chart
+      urls:
+        - https://github.com/pezhang/helm-release-API-test.git
+    type: git
+  version: 0.1.0
+spec:
+  replicaCount: 3


### PR DESCRIPTION
1. Add the YAML file with HelmRelease specifying spec field
2. This YAML file will be used for testing " A spec change update". It's related with https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/165. It changed the spec fields:   "replicaCount: 4" ->  "replicaCount: 3: 
