### PR TITLE
HelmRelease with spec fields unused by chart

### DIFF
--- a/examples/test-guestbook-spec-unused.yaml
+++ b/examples/test-guestbook-spec-unused.yaml
@@ -13,10 +13,10 @@ repo:
   chartName: nginx-chart
   source:
     github:
-      branch: gh-pages
-      chartPath: nginx-chart
+      branch: main
+      chartPath: /test/github/nginx-chart
       urls:
-        - https://github.com/pezhang/helm-release-API-test.git
+        - https://github.com/open-cluster-management/multicloud-operators-subscription-release.git
     type: git
   version: 0.1.0
 spec:

--- a/examples/test-guestbook-spec-unused.yaml
+++ b/examples/test-guestbook-spec-unused.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helmrelease-spec-test
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-spec-test
+repo:
+  chartName: nginx-chart
+  source:
+    github:
+      branch: gh-pages
+      chartPath: nginx-chart
+      urls:
+        - https://github.com/pezhang/helm-release-API-test.git
+    type: git
+  version: 0.1.0
+spec:
+  unused: unused


### PR DESCRIPTION
1. Add the YAML file with HelmRelease specifying spec field which not used by chart
2. This YAML file will be used for testing " Spec with fields that are not used in the chart."  In this YAML file, we define "unused: unused" in the spec filed.
