### PR TITLE
Add nginx-chart for HelmRelease test

### DIFF
--- a/test/github/nginx-chart/Chart.yaml
+++ b/test/github/nginx-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nginx-chart
+description: A Helm chart for Kubernetes - simple nginx chart for testing purpose
+type: application
+version: 0.1.0
+appVersion: 1.16.0

--- a/test/github/nginx-chart/templates/NOTES.txt
+++ b/test/github/nginx-chart/templates/NOTES.txt
@@ -1,0 +1,1 @@
+A simple nginx chart for testing purpose.

--- a/test/github/nginx-chart/templates/_helpers.tpl
+++ b/test/github/nginx-chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "guestbookapplication.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "guestbookapplication.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/test/github/nginx-chart/templates/deployment.yaml
+++ b/test/github/nginx-chart/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: guestbook
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "guestbookapplication.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "guestbookapplication.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP

--- a/test/github/nginx-chart/templates/service.yaml
+++ b/test/github/nginx-chart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: {{ template "guestbookapplication.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: {{ template "guestbookapplication.name" . }}
+    release: {{ .Release.Name }}

--- a/test/github/nginx-chart/values.yaml
+++ b/test/github/nginx-chart/values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: "1.14.2"


### PR DESCRIPTION
1. This patch is to solve https://github.com/open-cluster-management/multicloud-operators-subscription-release/pull/167/files#r593255104
2. Add chart to this github repo itself, the helm repo will refer to this link.
