### PR TITLE
Remove namespace from yaml file for spec change testing

### DIFF
--- a/examples/test-guestbook-spec-change.yaml
+++ b/examples/test-guestbook-spec-change.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: helmrelease-spec-test
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
This YAML file is mainly focus on spec change testing. And the change will be compared with previous YAML deployment.  It's necessary to distinguish a fully deployment and a changed deployment.

So we should remove unchanged but necessary part, and only keep the HelmRelease part in which the spec fields changes. Then we check if the  deployment is successful with the changes.
