### PR TITLE
Add yaml files for helmrepo testings

### DIFF
--- a/examples/test-guestbook-helmrepo-spec-change.yaml
+++ b/examples/test-guestbook-helmrepo-spec-change.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-helmrepo-spec-test
+repo:
+  chartName: nginx-chart
+  source:
+    helmRepo:
+      urls:
+        - https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/main/test/helmrepo/nginx-chart-0.1.0.tgz
+    type: helmrepo
+  version: 0.1.0
+spec:
+  replicaCount: 3

--- a/examples/test-guestbook-helmrepo-spec-unused.yaml
+++ b/examples/test-guestbook-helmrepo-spec-unused.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helmrelease-helmrepo-spec-test
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-helmrepo-spec-test
+repo:
+  chartName: nginx-chart
+  source:
+    helmRepo:
+      urls:
+        - https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/main/test/helmrepo/nginx-chart-0.1.0.tgz
+    type: helmrepo
+  version: 0.1.0
+spec:
+  unused: unused

--- a/examples/test-guestbook-helmrepo-spec.yaml
+++ b/examples/test-guestbook-helmrepo-spec.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helmrelease-helmrepo-spec-test
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-helmrepo-spec-test
+repo:
+  chartName: nginx-chart
+  source:
+    helmRepo:
+      urls:
+        - https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/main/test/helmrepo/nginx-chart-0.1.0.tgz
+    type: helmrepo
+  version: 0.1.0
+spec:
+  replicaCount: 4

--- a/examples/test-guestbook-helmrepo-upgrade.yaml
+++ b/examples/test-guestbook-helmrepo-upgrade.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-helmrepo-test
+repo:
+  chartName: nginx-chart
+  source:
+    helmRepo:
+      urls:
+        - https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/main/test/helmrepo/nginx-chart-0.2.0.tgz
+    type: helmrepo
+  version: 0.2.0

--- a/examples/test-guestbook-helmrepo.yaml
+++ b/examples/test-guestbook-helmrepo.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helmrelease-helmrepo-test
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: HelmRelease
+metadata:
+  name: guestbook
+  namespace: helmrelease-helmrepo-test
+repo:
+  chartName: nginx-chart
+  source:
+    helmRepo:
+      urls:
+        - https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/main/test/helmrepo/nginx-chart-0.1.0.tgz
+    type: helmrepo
+  version: 0.1.0


### PR DESCRIPTION
1. test-guestbook-helmrepo.yaml will be used  for helmrepo type chart deployment for basic
2. test-guestbook-helmrepo-upgrade.yaml will be used for helmrepo type chart deployment upgrade testing
3. test-guestbook-helmrepo-spec.yaml will be used for helmrepo type chart with spec fields testing
4. test-guestbook-helmrepo-spec-change.yaml will be used for helmrepo type chart with spec fields change testing
5. test-guestbook-helmrepo-spec-unused.yaml will be used for helmrepo type chart with unused spec fields testing