### PR TITLE
Add all 11 test IDs

### DIFF
--- a/apache-basic-auth/apache-basic-auth-service.yaml
+++ b/apache-basic-auth/apache-basic-auth-service.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache-basic-auth-pod
+  labels:
+    app: apache-basic-auth
+spec:
+  subdomain: chart-web
+  containers:
+  - name: apache-basic-auth
+    image: quay.io/pezhang/apache-basic-auth:latest
+    ports:
+    - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chart-web
+spec:
+  clusterIP: None
+  selector:
+    app: apache-basic-auth
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -100,6 +100,13 @@ if [ $? != 0 ]; then
     exit $?;
 fi
 
+echo -e "\nApply the Apache service with basic auth and helm chart\n"
+kubectl apply -f apache-basic-auth/apache-basic-auth-service.yaml
+
+if [ "$TRAVIS_BUILD" != 1 ]; then
+    echo -e "\nWait for Apache pod to be ready\n"
+    sleep 35
+fi
 
 echo -e "\nRun API test server\n"
 mkdir -p cluster_config
@@ -112,7 +119,7 @@ kind get kubeconfig > cluster_config/hub
 # over here, we are build the test server on the fly since, the `go get` will
 # mess up the go.mod file when doing the local test
 echo -e "\nGet the applifecycle-backend-e2e data"
-go get github.com/open-cluster-management/applifecycle-backend-e2e@v0.2.1
+go get github.com/open-cluster-management/applifecycle-backend-e2e@v0.2.3
 
 
 E2E_BINARY_NAME="applifecycle-backend-e2e"
@@ -137,6 +144,6 @@ function cleanup()
 trap cleanup EXIT
 
 echo -e "\nStart to run e2e test(s)\n"
-go test -v ./e2e
+go test -v ./e2e -timeout 30m
 
 exit 0;

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -97,6 +97,7 @@ func TestE2ESuite(t *testing.T) {
 	}
 
 	testIDs := []string{"RHACM4K-2346", "RHACM4K-1680", "RHACM4K-1701", "RHACM4K-2352", "RHACM4K-2347", "RHACM4K-2570", "RHACM4K-2569"}
+
 	stageTestIDs := []string{"RHACM4K-2348", "RHACM4K-1732", "RHACM4K-2566", "RHACM4K-2568"}
 
 	for _, tID := range testIDs {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	defaultAddr     = "http://localhost:8765"
-	runEndpoint     = "/run"
-	clusterEndpoint = "/clusters"
-	Success         = "succeed"
+	defaultAddr      = "http://localhost:8765"
+	runEndpoint      = "/run"
+	stageRunEndpoint = "/run/stage"
+	clusterEndpoint  = "/clusters"
+	Success          = "succeed"
 )
 
 type TResponse struct {
@@ -37,8 +38,12 @@ type TResponse struct {
 	Details interface{} `json:"details"`
 }
 
-func runner(runID string) error {
+func runner(runID string, runStage bool) error {
 	URL := fmt.Sprintf("%s%s?id=%s", defaultAddr, runEndpoint, runID)
+	if runStage {
+		URL = fmt.Sprintf("%s%s?id=%s", defaultAddr, stageRunEndpoint, runID)
+	}
+
 	resp, err := http.Get(URL)
 
 	if err != nil {
@@ -91,13 +96,20 @@ func TestE2ESuite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testIDs := []string{"release-001", "release-004"}
+	testIDs := []string{"RHACM4K-2346", "RHACM4K-1680", "RHACM4K-1701", "RHACM4K-2352", "RHACM4K-2347", "RHACM4K-2570", "RHACM4K-2569"}
+	stageTestIDs := []string{"RHACM4K-2348", "RHACM4K-1732", "RHACM4K-2566", "RHACM4K-2568"}
 
 	for _, tID := range testIDs {
-		if err := runner(tID); err != nil {
+		if err := runner(tID, false); err != nil {
 			t.Fatal(err)
 		}
 	}
+	t.Logf("HelmRelease e2e sub tests (1/2) %v passed", testIDs)
 
-	t.Logf("channel e2e tests %v passed", testIDs)
+	for _, tID := range stageTestIDs {
+		if err := runner(tID, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("HelmRelease e2e sub tests (2/2) %v passed", stageTestIDs)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -104,6 +104,7 @@ func TestE2ESuite(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
 	for _, tID := range stageTestIDs {
 		if err := runner(tID, true); err != nil {
 			t.Fatal(err)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -97,7 +97,6 @@ func TestE2ESuite(t *testing.T) {
 	}
 
 	testIDs := []string{"RHACM4K-2346", "RHACM4K-1680", "RHACM4K-1701", "RHACM4K-2352", "RHACM4K-2347", "RHACM4K-2570", "RHACM4K-2569"}
-
 	stageTestIDs := []string{"RHACM4K-2348", "RHACM4K-1732", "RHACM4K-2566", "RHACM4K-2568"}
 
 	for _, tID := range testIDs {
@@ -105,12 +104,11 @@ func TestE2ESuite(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Logf("HelmRelease e2e sub tests (1/2) %v passed", testIDs)
-
 	for _, tID := range stageTestIDs {
 		if err := runner(tID, true); err != nil {
 			t.Fatal(err)
 		}
 	}
-	t.Logf("HelmRelease e2e sub tests (2/2) %v passed", stageTestIDs)
+
+	t.Logf("The e2e tests %v, stage tests %v passed", testIDs, stageTestIDs)
 }


### PR DESCRIPTION
1. Add all test IDs to e2e
2. Extend the go time time from 10 minutes to 30 minutes
3. Update version with applifecycle-backend-e2e@v0.2.3
4. For case RHACM4K-1680, we need to deploy a pod with basic auth and chart. apache-basic-auth-service.yaml aims to solve this.