### PR TITLE
Trigger image rebuild to patch CVE-2022-28327

### DIFF
--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -134,7 +134,7 @@ if [ "$E2E_PS" != "" ]; then
     kill -9 $E2E_PS
 fi
 
-${E2E_BINARY_NAME} -cfg cluster_config &
+~/go/bin/${E2E_BINARY_NAME} -cfg cluster_config &
 
 sleep 10
 

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -54,7 +54,7 @@ else
     docker kill e2e || true
 fi
 
-kind delete cluster
+kind delete cluster --image=kindest/node:v1.21.1
 if [ $? != 0 ]; then
         exit $?;
 fi

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -48,7 +48,7 @@ if [ "$TRAVIS_BUILD" != 1 ]; then
     sed -i -e "s|image: .*:latest$|image: $BUILD_IMAGE|" deploy/operator.yaml
 
     echo -e "\nDownload and install KinD\n"
-    GO111MODULE=on go get sigs.k8s.io/kind
+    GO111MODULE=on go get sigs.k8s.io/kind@v0.13.0
 else
     echo -e "\nBuild is on Local ENV, will delete the API container first\n"
     docker kill e2e || true

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -54,12 +54,12 @@ else
     docker kill e2e || true
 fi
 
-kind delete cluster --image=kindest/node:v1.21.1
+kind delete cluster 
 if [ $? != 0 ]; then
         exit $?;
 fi
 
-kind create cluster
+kind create cluster --image=kindest/node:v1.21.1
 if [ $? != 0 ]; then
         exit $?;
 fi


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

For issue, [Bugzilla 2096667 CVE-2022-28327 multicluster-operators-subscription-release-container: golang: crypto/elliptic: panic caused by oversized scalar [rhacm-2] #23258
](https://github.com/stolostron/backlog/issues/23258)